### PR TITLE
test: add test for qpepre combination

### DIFF
--- a/dev/rwrf-process/tests/test_combine_rwrf_qpepre.py
+++ b/dev/rwrf-process/tests/test_combine_rwrf_qpepre.py
@@ -1,0 +1,47 @@
+import os
+import shutil
+import numpy as np
+from netCDF4 import Dataset
+
+from utils.config import CONFIG
+import combine_rwrf_qpepre as mod
+import fetch_rwrf as fetr
+
+# --- parameters ---
+date_str = "2019/08/03"
+hr_str = "00"
+rwrf_nc_orig = os.path.join("..", "data", "rwrf", "2019-08-03_00", "wrfout_d01_2019-08-03_00_interp")
+rwrf_nc_comb = os.path.join("..", "cache_test", "rwrf", "wrfout_d01_2019-08-03_00_interp_qpepre.nc")
+qpepre_txt = os.path.join("..", "data", "pptn", "qpepre_201908030000-201908030100_1_h.txt")
+qpepre_nc  = qpepre_txt.replace('.txt', '.nc')
+
+# Ensure cache folder exists
+os.makedirs(os.path.dirname(rwrf_nc_comb), exist_ok=True)
+
+# 1) Convert QPEPRE txt → nc if needed
+txt_base = qpepre_txt.replace('.txt','')
+if not os.path.exists(qpepre_nc):
+    print(f"Converting QPEPRE text → NetCDF: {qpepre_txt} → {qpepre_nc}")
+    mod.convert_txt_to_nc(date_str, hr_str)
+else:
+    print(f"QPEPRE NetCDF exists, skipping: {qpepre_nc}")
+
+# 2) Copy original RWRF to combined path
+shutil.copy(rwrf_nc_orig, rwrf_nc_comb)
+print(f"Copied RWRF: {rwrf_nc_orig} → {rwrf_nc_comb}")
+
+# 3) Apply combine_rwrf_qpepre to add ‘qpepre’ variable time to open datasets
+with Dataset(rwrf_nc_comb, 'r+') as rwrf_ds, Dataset(qpepre_nc, 'r') as qpe_ds:
+    print("Combining datasets…")
+    mod.combine_rwrf_qpepre(rwrf_ds, qpe_ds)
+    array_mod = rwrf_ds.variables['qpepre'][0, :, :]
+
+# 4) Validate that the new variable exists and has non-NaN values
+nan_count = np.isnan(array_mod).sum()
+total = array_mod.size
+print(f"qpepre var added: shape={array_mod.shape}, NaNs={nan_count}/{total}")
+
+# 5) Optional: Compare interpolation against direct griddata call for spot-check
+# (load raw qpepre points & RWRF lat/lon to validate)
+
+print("Test complete.")

--- a/dev/rwrf-process/tests/test_combine_rwrf_qpepre.py
+++ b/dev/rwrf-process/tests/test_combine_rwrf_qpepre.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import numpy as np
 from netCDF4 import Dataset
+from scipy.interpolate import griddata
 
 from utils.config import CONFIG
 import combine_rwrf_qpepre as mod
@@ -10,12 +11,12 @@ import fetch_rwrf as fetr
 # --- parameters ---
 date_str = "2019/08/03"
 hr_str = "00"
+
 rwrf_nc_orig = os.path.join("..", "data", "rwrf", "2019-08-03_00", "wrfout_d01_2019-08-03_00_interp")
 rwrf_nc_comb = os.path.join("..", "cache_test", "rwrf", "wrfout_d01_2019-08-03_00_interp_qpepre.nc")
 qpepre_txt = os.path.join("..", "data", "pptn", "qpepre_201908030000-201908030100_1_h.txt")
 qpepre_nc  = qpepre_txt.replace('.txt', '.nc')
 
-# Ensure cache folder exists
 os.makedirs(os.path.dirname(rwrf_nc_comb), exist_ok=True)
 
 # 1) Convert QPEPRE txt → nc if needed
@@ -34,14 +35,56 @@ print(f"Copied RWRF: {rwrf_nc_orig} → {rwrf_nc_comb}")
 with Dataset(rwrf_nc_comb, 'r+') as rwrf_ds, Dataset(qpepre_nc, 'r') as qpe_ds:
     print("Combining datasets…")
     mod.combine_rwrf_qpepre(rwrf_ds, qpe_ds)
-    array_mod = rwrf_ds.variables['qpepre'][0, :, :]
+    qpe_interp = rwrf_ds.variables['qpepre'][0, :, :]
 
 # 4) Validate that the new variable exists and has non-NaN values
-nan_count = np.isnan(array_mod).sum()
-total = array_mod.size
-print(f"qpepre var added: shape={array_mod.shape}, NaNs={nan_count}/{total}")
+nan_count = np.isnan(qpe_interp).sum()
+total = qpe_interp.size
+print(f"qpepre var added: shape={qpe_interp.shape}, NaNs={nan_count}/{total}")
 
-# 5) Optional: Compare interpolation against direct griddata call for spot-check
-# (load raw qpepre points & RWRF lat/lon to validate)
+# 5) Extract raw RWRF precip from the original file
+with Dataset(rwrf_nc_orig, 'r') as orig_ds:
+    rwrf_raw = orig_ds.variables['RAINNC'][0, :, :].data
+
+with Dataset(rwrf_nc_comb, 'r') as comb_ds:
+    rwrf_comb = comb_ds.variables['RAINNC'][0, :, :].data
+
+# 6) Compare first and last rows for RWRF, QPEPRE, and combined
+for idx in [0, -1]:
+    print(f"\nRow {idx} comparison:")
+    print(f"  RWRF raw       : {rwrf_raw[idx, :]}")
+    print(f"  QPEPRE interp  : {qpe_interp[idx, :]}")
+    print(f"  RWRF combined  : {rwrf_comb[idx, :]}")
+    # difference between combined and raw
+    diff = rwrf_comb[idx, :] - rwrf_raw[idx, :]
+    print(f"  Diff (comb - raw): {diff}")
+
+# 6) Spot-check with direct griddata interpolation
+#    load the original txt points: lon, lat, precip
+pts = np.loadtxt(qpepre_txt)  # assumes columns: lon, lat, precip
+lons_pts, lats_pts, vals_pts = pts[:,0], pts[:,1], pts[:,2]
+
+# get the WRF grid
+with Dataset(rwrf_nc_orig, 'r') as orig_ds:
+    lons_wrf = orig_ds.variables['XLONG'][0, :, :]
+    lats_wrf = orig_ds.variables['XLAT'][0, :, :]
+
+# perform direct interpolation
+qpe_direct = griddata(
+    (lons_pts, lats_pts),
+    vals_pts,
+    (lons_wrf, lats_wrf),
+    method='linear'
+)
+
+# compare to in-file result
+for idx in [0, -1]:
+    direct_row = qpe_direct[idx, :]
+    interp_row = qpe_interp[idx, :]
+    print(f"\nDirect griddata vs. in-file interp (row {idx}):")
+    print(f"  direct  : {direct_row}")
+    print(f"  in-file : {interp_row}")
+    print(f"  Δ        : {interp_row - direct_row}")
+
 
 print("Test complete.")

--- a/dev/rwrf-process/tests/test_combine_rwrf_qpepre.py
+++ b/dev/rwrf-process/tests/test_combine_rwrf_qpepre.py
@@ -1,90 +1,53 @@
 import os
-import shutil
-import numpy as np
-from netCDF4 import Dataset
-from scipy.interpolate import griddata
+import pytest
+import xarray as xr
 
 from utils.config import CONFIG
 import combine_rwrf_qpepre as mod
 import fetch_rwrf as fetr
+from utils.txt2ds import load_qpepre, qpepre_stats
 
-# --- parameters ---
-date_str = "2019/08/03"
-hr_str = "00"
+# parameters
+DATE = "2019/08/03"
+HOUR = "00"
 
-rwrf_nc_orig = os.path.join("..", "data", "rwrf", "2019-08-03_00", "wrfout_d01_2019-08-03_00_interp")
-rwrf_nc_comb = os.path.join("..", "cache_test", "rwrf", "wrfout_d01_2019-08-03_00_interp_qpepre.nc")
-qpepre_txt = os.path.join("..", "data", "pptn", "qpepre_201908030000-201908030100_1_h.txt")
-qpepre_nc  = qpepre_txt.replace('.txt', '.nc')
+@pytest.fixture
+def paths(tmp_path, monkeypatch):
+    """
+    Set CONFIG paths to temporary dirs, ensure data is in place, 
+    run conversion & combine once for all tests.
+    """
+    rwrf_nc_orig = os.path.join("..", "data", "rwrf", "2019-08-03_00", "wrfout_d01_2019-08-03_00_interp")
+    rwrf_nc_comb = os.path.join("..", "data", "rwrf", "2019-08-03_00", "wrfout_d01_2019-08-03_00_interp_qpepre.nc")
+    qpepre_txt = os.path.join("../", "data", "pptn", "qpepre_201908030000-201908030100_1_h.txt")
 
-os.makedirs(os.path.dirname(rwrf_nc_comb), exist_ok=True)
+    return {
+        "orig": rwrf_nc_orig,
+        "comb": rwrf_nc_comb,
+        "txt": qpepre_txt,
+    }
 
-# 1) Convert QPEPRE txt → nc if needed
-txt_base = qpepre_txt.replace('.txt','')
-if not os.path.exists(qpepre_nc):
-    print(f"Converting QPEPRE text → NetCDF: {qpepre_txt} → {qpepre_nc}")
-    mod.convert_txt_to_nc(date_str, hr_str)
-else:
-    print(f"QPEPRE NetCDF exists, skipping: {qpepre_nc}")
+def test_latlon_match(paths):
+    ds = xr.open_dataset(paths["comb"], decode_times=False)
+    # XLAT
+    assert ds["qpepre"]["XLAT"].equals(ds["RAINNC"]["XLAT"])
+    # XLONG
+    assert ds["qpepre"]["XLONG"].equals(ds["RAINNC"]["XLONG"])
+    pass
 
-# 2) Copy original RWRF to combined path
-shutil.copy(rwrf_nc_orig, rwrf_nc_comb)
-print(f"Copied RWRF: {rwrf_nc_orig} → {rwrf_nc_comb}")
+def test_qpe_stats(paths):
+    # from TXT
+    txt_ds = load_qpepre(paths["txt"])
+    mean_txt, std_txt = qpepre_stats(txt_ds)
 
-# 3) Apply combine_rwrf_qpepre to add ‘qpepre’ variable time to open datasets
-with Dataset(rwrf_nc_comb, 'r+') as rwrf_ds, Dataset(qpepre_nc, 'r') as qpe_ds:
-    print("Combining datasets…")
-    mod.combine_rwrf_qpepre(rwrf_ds, qpe_ds)
-    qpe_interp = rwrf_ds.variables['qpepre'][0, :, :]
+    # from combined NC
+    ds = xr.open_dataset(paths["comb"], decode_times=False)
+    mean_nc = float(ds["qpepre"].mean().item())
+    std_nc  = float(ds["qpepre"].std().item())
 
-# 4) Validate that the new variable exists and has non-NaN values
-nan_count = np.isnan(qpe_interp).sum()
-total = qpe_interp.size
-print(f"qpepre var added: shape={qpe_interp.shape}, NaNs={nan_count}/{total}")
+    assert mean_nc == pytest.approx(mean_txt, rel=1e-3)
+    assert std_nc  == pytest.approx(std_txt,  rel=1e-3)
 
-# 5) Extract raw RWRF precip from the original file
-with Dataset(rwrf_nc_orig, 'r') as orig_ds:
-    rwrf_raw = orig_ds.variables['RAINNC'][0, :, :].data
-
-with Dataset(rwrf_nc_comb, 'r') as comb_ds:
-    rwrf_comb = comb_ds.variables['RAINNC'][0, :, :].data
-
-# 6) Compare first and last rows for RWRF, QPEPRE, and combined
-for idx in [0, -1]:
-    print(f"\nRow {idx} comparison:")
-    print(f"  RWRF raw       : {rwrf_raw[idx, :]}")
-    print(f"  QPEPRE interp  : {qpe_interp[idx, :]}")
-    print(f"  RWRF combined  : {rwrf_comb[idx, :]}")
-    # difference between combined and raw
-    diff = rwrf_comb[idx, :] - rwrf_raw[idx, :]
-    print(f"  Diff (comb - raw): {diff}")
-
-# 6) Spot-check with direct griddata interpolation
-#    load the original txt points: lon, lat, precip
-pts = np.loadtxt(qpepre_txt)  # assumes columns: lon, lat, precip
-lons_pts, lats_pts, vals_pts = pts[:,0], pts[:,1], pts[:,2]
-
-# get the WRF grid
-with Dataset(rwrf_nc_orig, 'r') as orig_ds:
-    lons_wrf = orig_ds.variables['XLONG'][0, :, :]
-    lats_wrf = orig_ds.variables['XLAT'][0, :, :]
-
-# perform direct interpolation
-qpe_direct = griddata(
-    (lons_pts, lats_pts),
-    vals_pts,
-    (lons_wrf, lats_wrf),
-    method='linear'
-)
-
-# compare to in-file result
-for idx in [0, -1]:
-    direct_row = qpe_direct[idx, :]
-    interp_row = qpe_interp[idx, :]
-    print(f"\nDirect griddata vs. in-file interp (row {idx}):")
-    print(f"  direct  : {direct_row}")
-    print(f"  in-file : {interp_row}")
-    print(f"  Δ        : {interp_row - direct_row}")
-
-
-print("Test complete.")
+def test_original_has_no_qpepre(paths):
+    ds_orig = xr.open_dataset(paths["orig"], decode_times=False)
+    assert "qpepre" not in ds_orig.data_vars


### PR DESCRIPTION
## Types of changes
<!--Please remove the types that do not apply to this change-->
* **Test**

## Description
<!--Describe what the change is-->
This PR add test for PR#9. The test includes:
### test_latlon_match(paths)
Opens the combined NetCDF (paths["comb"]-> "wrfout_d01_2019-08-03_00_interp_qpepre" in this case).
1. Verifies that the latitude (XLAT) arrays in the qpepre and RAINNC variables are identical.
2. Verifies that the longitude (XLONG) arrays in the qpepre and RAINNC variables are identical.

### test_qpe_stats(paths)

From the original text data

1. Loads the QPEPRE points from the .txt file (paths["txt"]) via load_qpepre().
2. Computes the mean and standard deviation of those raw point values using qpepre_stats().

From the combined NetCDF

1. Opens the combined NetCDF and extracts the qpepre variable.
2. Computes its mean and standard deviation (converted to Python floats).
3. Asserts that the NetCDF-derived statistics agree with the text-derived ones to within a relative tolerance of 0.1%.

### test_original_has_no_qpepre(paths)

Opens the original NetCDF (paths["orig"]).

1. Checks that qpepre does not exist among its data variables, ensuring that QPEPRE was only introduced by the combination step.


## Steps to Test This Pull Request
1. Execute pytest:
   ```bash
    pytest -q
    ```
2. See if it had passed or failed the three tests.