### PR TITLE
feat: add Slurm scripts for training on HPC

### DIFF
--- a/dev/Makefile
+++ b/dev/Makefile
@@ -63,6 +63,7 @@ make_cache:
 	python nc_to_npz.py
 
 run:
+	$(MAKE) pull
 	$(MAKE) log_dir
 	$(MAKE) make_cache
 	$(MAKE) clear_data	

--- a/dev/rdd_run.py
+++ b/dev/rdd_run.py
@@ -1,0 +1,19 @@
+#This code will run in 3hr after it is started  
+import time
+import logging
+
+start_time = time.time()
+flag = True
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logging.info("Process started.")
+
+while(flag):
+   #if time.time() - start_time > 10800:
+   if time.time() - start_time > 100:
+       print("passed, stopping the process.")
+       flag = False
+       break
+   time.sleep(60)  # Check every minute
+
+logging.info("Process ended.")

--- a/dev/run.sh
+++ b/dev/run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+num_tests=$(python3 - <<'EOF'
+import yaml
+with open("test_plan.yaml") as f:
+    data = yaml.safe_load(f)
+print(len(data["tests"]))
+EOF
+)
+
+echo "Found $num_tests tests"
+make reset
+
+for i in $(seq 0 $((num_tests-1))); do
+    echo "Running test $i"
+    make run
+done

--- a/dev/scripts/1N.sh
+++ b/dev/scripts/1N.sh
@@ -5,22 +5,21 @@
 #SBATCH -p <PARTITION_NAME>      # need partition name
 #SBATCH -o %x.%j.out           # output log
 #SBATCH -e %x.%j.err           # error log
-#SBATCH --gpus-per-node=1      # number of GPU per node
-# job runtime limit
-#SBATCH -t 01:00:00
+#SBATCH --gpus-per-node=1      # number of GPUs per node
+#SBATCH -t 01:00:00            # job runtime limit
 
 HOMEDIR=<HOME_DIR>  # replace with actual home directory
 SQSH=<SQSH_FILE>  # replace with actual SQSH file
 PARTITION=<PARTITION_NAME>  # replace with actual partition name
 
-echo -e "Running on hosts: $(echo $(scontrol show hostname))"
+echo -e "Running on hosts: $(scontrol show hostname)"
 
-srun -N 1 -p ${PARTITION}  --mpi=pmix --gres=gpu:1 \
---container-image ${HOMEDIR}${SQSH} \
---container-writable \
---container-remap-root \
---container-mounts ${HOMEDIR}/projects/physicsnemo:/workspace \
-bash -c "
-cd dev
-# make run
-"
+srun -N 1 -p ${PARTITION} --mpi=pmix --gres=gpu:1 \
+  --container-image ${HOMEDIR}${SQSH} \
+  --container-writable \
+  --container-remap-root \
+  --container-mounts ${HOMEDIR}:/workspace \
+  bash -c "
+    cd projects/physicsnemo/dev
+    make run
+  "

--- a/dev/scripts/1N.sh
+++ b/dev/scripts/1N.sh
@@ -2,7 +2,7 @@
 #SBATCH -J job_name            # set job name
 #SBATCH -N 1                   # number of nodes
 #SBATCH --ntasks-per-node=1    # number of tasks per node
-#SBATCH -p <PARTITION_NAME>      # need partition name
+#SBATCH -p <Group Name>     # partition name
 #SBATCH -o %x.%j.out           # output log
 #SBATCH -e %x.%j.err           # error log
 #SBATCH --gpus-per-node=1      # number of GPUs per node
@@ -15,7 +15,7 @@ DATAPATH=<DATA_PATH> # replace with actual data path
 
 echo -e "Running on hosts: $(scontrol show hostname)"
 
-srun -N 1 -p ${PARTITION} --mpi=pmix --gres=gpu:1 \
+srun -N 1 -p ${PARTITION}  --mpi=pmix --gres=gpu:1 \
   --container-image ${HOMEDIR}${SQSH} \
   --container-writable \
   --container-remap-root \
@@ -23,5 +23,5 @@ srun -N 1 -p ${PARTITION} --mpi=pmix --gres=gpu:1 \
 ${HOMEDIR}/${DATAPATH}/ \
   bash -c "
     cd dev
-    make run
+    #make run
   "

--- a/dev/scripts/1N.sh
+++ b/dev/scripts/1N.sh
@@ -15,9 +15,12 @@ PARTITION=<PARTITION_NAME>  # replace with actual partition name
 
 echo -e "Running on hosts: $(echo $(scontrol show hostname))"
 
-srun -N 1 -p ${PARTITION}  --mpi=pmix --gres=gpu:8 --ntasks-per-node 8 \
---container-image ${HOMEDIR}/${SQSH} \
+srun -N 1 -p ${PARTITION}  --mpi=pmix --gres=gpu:1 \
+--container-image ${HOMEDIR}${SQSH} \
 --container-writable \
 --container-remap-root \
 --container-mounts ${HOMEDIR}/projects/physicsnemo:/workspace \
---pty /bin/bash
+bash -c "
+cd dev
+# make run
+"

--- a/dev/scripts/1N.sh
+++ b/dev/scripts/1N.sh
@@ -11,6 +11,7 @@
 HOMEDIR=<HOME_DIR>  # replace with actual home directory
 SQSH=<SQSH_FILE>  # replace with actual SQSH file
 PARTITION=<PARTITION_NAME>  # replace with actual partition name
+DATAPATH=<DATA_PATH> # replace with actual data path
 
 echo -e "Running on hosts: $(scontrol show hostname)"
 
@@ -18,8 +19,9 @@ srun -N 1 -p ${PARTITION} --mpi=pmix --gres=gpu:1 \
   --container-image ${HOMEDIR}${SQSH} \
   --container-writable \
   --container-remap-root \
-  --container-mounts ${HOMEDIR}:/workspace \
+  --container-mounts=${HOMEDIR}/projects/physicsnemo:/workspace,\
+${HOMEDIR}/${DATAPATH}/ \
   bash -c "
-    cd projects/physicsnemo/dev
+    cd dev
     make run
   "

--- a/dev/scripts/1N.sh
+++ b/dev/scripts/1N.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#SBATCH -J job_name            # set job name
+#SBATCH -N 1                   # number of nodes
+#SBATCH --ntasks-per-node=1    # number of tasks per node
+#SBATCH -p <PARTITION_NAME>      # need partition name
+#SBATCH -o %x.%j.out           # output log
+#SBATCH -e %x.%j.err           # error log
+#SBATCH --gpus-per-node=1      # number of GPU per node
+# job runtime limit
+#SBATCH -t 01:00:00
+
+HOMEDIR=<HOME_DIR>  # replace with actual home directory
+SQSH=<SQSH_FILE>  # replace with actual SQSH file
+PARTITION=<PARTITION_NAME>  # replace with actual partition name
+
+echo -e "Running on hosts: $(echo $(scontrol show hostname))"
+
+srun -N 1 -p ${PARTITION}  --mpi=pmix --gres=gpu:8 --ntasks-per-node 8 \
+--container-image ${HOMEDIR}/${SQSH} \
+--container-writable \
+--container-remap-root \
+--container-mounts ${HOMEDIR}/projects/physicsnemo:/workspace \
+--pty /bin/bash

--- a/dev/scripts/1N_orig.sh
+++ b/dev/scripts/1N_orig.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#SBATCH -J job_name            # set job name
+#SBATCH -N 1                   # number of nodes
+#SBATCH --ntasks-per-node=1    # number of tasks per node
+#SBATCH -p <Group Name>     # need partition name
+#SBATCH -o %x.%j.out           # output log
+#SBATCH -e %x.%j.err           # error log
+#SBATCH --gpus-per-node=1      # number of GPU per node
+# job runtime limit
+#SBATCH -t 01:00:00
+
+echo -e "Running on hosts: $(echo $(scontrol show hostname))"
+
+srun -N 1 -p <Group Name> --mpi=pmix --gres=gpu:1 --ntasks-per-node 1 \
+  --container-image /mnt/home/usr/<container>.sqsh \
+  --container-writable \
+  --container-remap-root \
+  --container-mounts=/mnt/home/usr/projects/physicsnemo:/workspace,\
+/mnt/home/usr/usr/data:/mnt/data \
+  --container-workdir=/workspace/dev \
+  bash -c "
+  make run
+  "

--- a/dev/scripts/1N_temp.sh
+++ b/dev/scripts/1N_temp.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#SBATCH -J job_name            # set job name
+#SBATCH -N 1                   # number of nodes
+#SBATCH --ntasks-per-node=1    # number of tasks per node
+#SBATCH -p <Group Name>     # need partition name
+#SBATCH -o %x.%j.out           # output log
+#SBATCH -e %x.%j.err           # error log
+#SBATCH --gpus-per-node=1      # number of GPU per node
+# job runtime limit
+#SBATCH -t 01:00:00
+
+HOMEDIR=/mnt/home/usr
+SQSH=/<container>.sqsh  
+PARTITION=<Group Name>
+
+echo -e "Running on hosts: $(echo $(scontrol show hostname))"
+
+srun -N 1 -p ${PARTITION}  --mpi=pmix \
+--container-image ${HOMEDIR}${SQSH} \
+--container-writable \
+--container-remap-root \
+--container-mounts ${HOMEDIR}/projects/physicsnemo:/workspace \
+--pty /bin/bash

--- a/dev/scripts/1N_test.sh
+++ b/dev/scripts/1N_test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#SBATCH -J job_name            # set job name
+#SBATCH -N 1                   # number of nodes
+#SBATCH --ntasks-per-node=1    # number of tasks per node
+#SBATCH -p <Group Name>     # need partition name
+#SBATCH -o %x.%j.out           # output log
+#SBATCH -e %x.%j.err           # error log
+#SBATCH --gpus-per-node=1      # number of GPU per node
+# job runtime limit
+#SBATCH -t 01:00:00
+
+echo -e "Running on hosts: $(echo $(scontrol show hostname))"
+
+srun -N 1 -p <Group Name> --mpi=pmix --gres=gpu:1 --ntasks-per-node 1 \
+  --container-image /mnt/home/usr/<container>.sqsh \
+  --container-writable \
+  --container-remap-root \
+  --container-mounts=/mnt/home/usr/projects/physicsnemo:/workspace,\
+/mnt/home/usr/usr/data:/mnt/data,\
+/mnt/home/usr/<Group Name>:/mnt/ncdr \
+  --container-workdir=/workspace/dev \
+  bash -c "
+  make run
+  "

--- a/dev/scripts/1N_v2.sh
+++ b/dev/scripts/1N_v2.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#SBATCH -J job_name            # set job name
+#SBATCH -N 1                   # number of nodes
+#SBATCH --ntasks-per-node=1    # number of tasks per node
+#SBATCH -p <Group Name>     # need partition name
+#SBATCH -o %x.%j.out           # output log
+#SBATCH -e %x.%j.err           # error log
+#SBATCH --gpus-per-node=1      # number of GPU per node
+# job runtime limit
+#SBATCH -t 01:00:00
+
+HOMEDIR=/mnt/home/usr
+SQSH=/<container>.sqsh  
+PARTITION=<Group Name>
+
+echo -e "Running on hosts: $(echo $(scontrol show hostname))"
+
+srun -N 1 -p ${PARTITION}  --mpi=pmix --gres=gpu:1 \
+--container-image ${HOMEDIR}/${SQSH} \
+--container-writable \
+--container-remap-root \
+--container-mounts ${HOMEDIR}/projects/physicsnemo:/workspace \
+bash -c "
+cd dev
+# make run
+"

--- a/dev/scripts/2N.sh
+++ b/dev/scripts/2N.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#SBATCH -J job_name            # set job name
+#SBATCH -N 2                   # number of nodes
+#SBATCH --ntasks-per-node=1    # number of tasks per node
+#SBATCH -p partition           # need partition name
+#SBATCH -o %x.%j.out           # output log
+#SBATCH -e %x.%j.err           # error log
+#SBATCH --gpus-per-node=1      # number of GPU per node
+# job runtime limit
+##SBATCH -t 01:00:00
+
+SQSH=/path/to/physicsnemo_25.03.sqsh  
+CNAME=physicsnemo_25_03
+WORKDIR=/workspace
+HOST_WORKDIR=$PWD
+
+set -euo pipefail
+
+# 用srun讓每個節點做同樣的事
+srun --label bash -lc "
+  set -euo pipefail
+  if ! enroot list | grep -q '^${CNAME}\$'; then
+    enroot create -n '${CNAME}' '${SQSH}'
+  fi
+  enroot start \
+    --mount '${HOST_WORKDIR}:${WORKDIR}' \
+    --env PIP_CACHE_DIR=/tmp/pipcache \
+    --env REPO_URL=https://github.com/runberry/physicsnemo.git \
+    --env REPO_DIR=${WORKDIR}/physicsnemo \
+    --env BRANCH=exp/tp1 \
+    '${CNAME}' bash -lc 'cd ${WORKDIR} && chmod +x hpl.sh && ./hpl.sh'
+"
+
+# 如果有 Pyxis srun可寫
+: <<'COMMENT'
+srun --label \
+     --mpi=pmix \
+     --export=ALL,PIP_CACHE_DIR=/tmp/pipcache,REPO_URL=https://github.com/runberry/physicsnemo.git,REPO_DIR=/workspace/physicsnemo,BRANCH=exp/tp1 \
+     --container-image=$SQSH \
+     --container-mounts=$PWD:/workspace \
+     --container-workdir=/workspace \
+     bash -lc "chmod +x hpl.sh && ./hpl.sh"
+COMMENT

--- a/dev/scripts/2N.sh
+++ b/dev/scripts/2N.sh
@@ -9,9 +9,9 @@
 # job runtime limit
 ##SBATCH -t 01:00:00
 
-SQSH=/path/to/physicsnemo_25.03.sqsh  
+SQSH=/home/physicsnemo_25.03.sqsh  
 CNAME=physicsnemo_25_03
-WORKDIR=/workspace
+WORKDIR=/tmp
 HOST_WORKDIR=$PWD
 
 set -euo pipefail
@@ -25,7 +25,7 @@ srun --label bash -lc "
   enroot start \
     --mount '${HOST_WORKDIR}:${WORKDIR}' \
     --env PIP_CACHE_DIR=/tmp/pipcache \
-    --env REPO_URL=https://github.com/runberry/physicsnemo.git \
+    --env REPO_URL=https://github.com/running-berry/physicsnemo.git \
     --env REPO_DIR=${WORKDIR}/physicsnemo \
     --env BRANCH=exp/tp1 \
     '${CNAME}' bash -lc 'cd ${WORKDIR} && chmod +x hpl.sh && ./hpl.sh'

--- a/dev/scripts/RDD1.sh
+++ b/dev/scripts/RDD1.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#SBATCH -J job_name            # set job name
+#SBATCH -N 1                   # number of nodes
+#SBATCH --ntasks-per-node=1    # number of tasks per node
+#SBATCH -p <Group Name>     # need partition name
+#SBATCH -w cnode3-001          # specify node
+#SBATCH -o %x.%j.out           # output log
+#SBATCH -e %x.%j.err           # error log
+#SBATCH --gpus-per-node=1      # number of GPU per node
+#SBATCH -t 7-00:00:00                      # job runtime limit
+
+echo -e "Running on hosts: $(echo $(scontrol show hostname))"
+
+srun -N 1 -w cnode3-001 -p <Group Name> --mpi=pmix --gres=gpu:1 --ntasks-per-node 1 \
+  --container-image /mnt/home/usr/<container>.sqsh \
+  --container-writable \
+  --container-remap-root \
+  --container-mounts=/mnt/home/usr/projects/physicsnemo:/workspace,\
+/mnt/home/usr/usr/data:/mnt/data \
+  --container-workdir=/workspace/dev \
+  bash -c "
+  python rdd_run.py
+  "

--- a/dev/scripts/RDD2.sh
+++ b/dev/scripts/RDD2.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#SBATCH -J job_name            # set job name
+#SBATCH -N 1                   # number of nodes
+#SBATCH --ntasks-per-node=1    # number of tasks per node
+#SBATCH -p <Group Name>     # need partition name
+#SBATCH -w cnode3-002      # need partition name
+#SBATCH -o %x.%j.out           # output log
+#SBATCH -e %x.%j.err           # error log
+#SBATCH --gpus-per-node=1      # number of GPU per node
+# job runtime limit
+#SBATCH -t 7-00:00:00             
+
+echo -e "Running on hosts: $(echo $(scontrol show hostname))"
+
+srun -N 1 -w cnode3-002 -p <Group Name> --mpi=pmix --gres=gpu:1 --ntasks-per-node 1 \
+  --container-image /mnt/home/usr/<container>.sqsh \
+  --container-writable \
+  --container-remap-root \
+  --container-mounts=/mnt/home/usr/projects/physicsnemo:/workspace,\
+/mnt/home/usr/usr/data:/mnt/data \
+  --container-workdir=/workspace/dev \
+  bash -c "
+  python rdd_run.py
+  "

--- a/dev/scripts/RDD3.sh
+++ b/dev/scripts/RDD3.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#SBATCH -J job_name            # set job name
+#SBATCH -N 1                   # number of nodes
+#SBATCH --ntasks-per-node=1    # number of tasks per node
+#SBATCH -p <Group Name>     # need partition name
+#SBATCH -w cnode3-003      # need partition name
+#SBATCH -o %x.%j.out           # output log
+#SBATCH -e %x.%j.err           # error log
+#SBATCH --gpus-per-node=1      # number of GPU per node
+# job runtime limit
+#SBATCH -t 7-00:00:00             
+
+echo -e "Running on hosts: $(echo $(scontrol show hostname))"
+
+srun -N 1 -w cnode3-003 -p <Group Name> --mpi=pmix --gres=gpu:1 --ntasks-per-node 1 \
+  --container-image /mnt/home/usr/<container>.sqsh \
+  --container-writable \
+  --container-remap-root \
+  --container-mounts=/mnt/home/usr/projects/physicsnemo:/workspace,\
+/mnt/home/usr/usr/data:/mnt/data \
+  --container-workdir=/workspace/dev \
+  bash -c "
+  python rdd_run.py
+  "

--- a/dev/scripts/RDD4.sh
+++ b/dev/scripts/RDD4.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#SBATCH -J job_name            # set job name
+#SBATCH -N 1                   # number of nodes
+#SBATCH --ntasks-per-node=1    # number of tasks per node
+#SBATCH -p <Group Name>     # need partition name
+#SBATCH -w cnode3-004      # need partition name
+#SBATCH -o %x.%j.out           # output log
+#SBATCH -e %x.%j.err           # error log
+#SBATCH --gpus-per-node=1      # number of GPU per node
+# job runtime limit
+#SBATCH -t 7-00:00:00              
+
+echo -e "Running on hosts: $(echo $(scontrol show hostname))"
+
+srun -N 1 -w cnode3-004 -p <Group Name> --mpi=pmix --gres=gpu:1 --ntasks-per-node 1 \
+  --container-image /mnt/home/usr/<container>.sqsh \
+  --container-writable \
+  --container-remap-root \
+  --container-mounts=/mnt/home/usr/projects/physicsnemo:/workspace,\
+/mnt/home/usr/usr/data:/mnt/data \
+  --container-workdir=/workspace/dev \
+  bash -c "
+  python rdd_run.py
+  "

--- a/dev/scripts/RDD_RUN2.sh
+++ b/dev/scripts/RDD_RUN2.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+LOGFILE="job_id.log"
+DATE="2025-08-26"
+
+# 每一欄的 script
+#SCRIPTS=("RDD1.sh" "RDD2.sh" "RDD3.sh" "RDD4.sh")
+SCRIPTS=("RDD2.sh" "RDD3.sh")
+
+# 表格時間，對應四欄
+#TIMES_COL1=("05:30:00" "08:30:00" "09:00:00" "12:00:00" "12:30:00" "15:30:00" "16:00:00" "19:00:00")
+TIMES_COL2=("05:45:00" "09:15:00" "12:45:00" "16:15:00" "19:30:00")
+TIMES_COL3=("07:30:00" "11:00:00" "14:30:00" "18:00:00" "21:30:00")
+#TIMES_COL4=("07:45:00" "10:45:00" "11:15:00" "14:15:00" "14:45:00" "17:45:00" "18:15:00" "21:15:00")
+
+
+# 把所有欄位放在陣列方便迴圈
+#ALL_TIMES=(TIMES_COL1[@] TIMES_COL2[@] TIMES_COL3[@] TIMES_COL4[@])
+ALL_TIMES=(TIMES_COL2[@] TIMES_COL3[@])
+
+# 迴圈跑四欄
+for i in {0..1}; do
+    SCRIPT=${SCRIPTS[$i]}
+    TIMES=(${!ALL_TIMES[$i]})
+
+    for t in "${TIMES[@]}"; do
+        OUTPUT=$(sbatch --begin="${DATE}T${t}" $SCRIPT)
+        JOBID=$(echo $OUTPUT | awk '{print $4}')
+
+	# 等待節點分配（避免記錄到空）
+        sleep 5
+        NODE=$(squeue -j $JOBID -o "%N" -h)
+
+        echo "$(date '+%F %T') $JOBID ${DATE}T${t} $SCRIPT $NODE" >> $LOGFILE
+        echo "Submitted $SCRIPT at ${DATE}T${t}, JobID=$JOBID, Node=$NODE"
+    done
+done

--- a/dev/scripts/RUN_RDD.sh
+++ b/dev/scripts/RUN_RDD.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+
+JOBID=$(sbatch --begin="2025-08-21T22:06:00" RDD2.sh | awk '{print $4}')
+sleep 5
+NODE=$(squeue -j $JOBID -o "%N" -h)
+
+echo "$(date '+%F %T') $JOBID $BEGIN $NODE" >> job_id.log
+
+
+
+#!/bin/bash
+
+LOGFILE="job_id.log"
+DATE="2025-08-22"
+
+# 每一欄的 script
+SCRIPTS=("RDD1.sh" "RDD2.sh" "RDD3.sh" "RDD4.sh")
+
+# 表格時間，對應四欄
+TIMES_COL1=("05:30:00" "08:30:00" "09:00:00" "12:00:00" "12:30:00" "15:30:00" "16:00:00" "19:00:00")
+TIMES_COL2=("05:45:00" "08:45:00" "09:15:00" "12:15:00" "12:45:00" "15:45:00" "16:15:00" "19:15:00")
+TIMES_COL3=("07:30:00" "10:30:00" "11:00:00" "14:00:00" "14:30:00" "17:30:00" "18:00:00" "21:00:00")
+TIMES_COL4=("07:45:00" "10:45:00" "11:15:00" "14:15:00" "14:45:00" "17:45:00" "18:15:00" "21:15:00")
+
+# 把所有欄位放在陣列方便迴圈
+ALL_TIMES=(TIMES_COL1[@] TIMES_COL2[@] TIMES_COL3[@] TIMES_COL4[@])
+
+# 迴圈跑四欄
+for i in {0..3}; do
+    SCRIPT=${SCRIPTS[$i]}
+    TIMES=(${!ALL_TIMES[$i]})
+
+    for t in "${TIMES[@]}"; do
+        OUTPUT=$(sbatch --begin="${DATE}T${t}" $SCRIPT)
+        JOBID=$(echo $OUTPUT | awk '{print $4}')
+
+        # 等待節點分配（避免記錄到空）
+        NODE=""
+        while [ -z "$NODE" ] || [ "$NODE" == "(null)" ]; do
+            NODE=$(squeue -j $JOBID -o "%N" -h)
+            [ -z "$NODE" ] && sleep 2
+        done
+
+        echo "$(date '+%F %T') $JOBID ${DATE}T${t} $SCRIPT $NODE" >> $LOGFILE
+        echo "Submitted $SCRIPT at ${DATE}T${t}, JobID=$JOBID, Node=$NODE"
+    done
+done
+
+
+
+
+
+
+

--- a/dev/scripts/TN1.sh
+++ b/dev/scripts/TN1.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#SBATCH -J job_name            # set job name
+#SBATCH -N 1                   # number of nodes
+#SBATCH --ntasks-per-node=1    # number of tasks per node
+#SBATCH -p <Group Name>     # need partition name
+#SBATCH -w cnode3-001          # specify node
+#SBATCH -o %x.%j.out           # output log
+#SBATCH -e %x.%j.err           # error log
+#SBATCH --gpus-per-node=1      # number of GPU per node
+#SBATCH -t 7-00:00:00                      # job runtime limit
+
+echo -e "Running on hosts: $(echo $(scontrol show hostname))"
+
+num_tests=$(python3 - <<'EOF'
+import yaml
+with open("../test_plan.yaml") as f:
+    data = yaml.safe_load(f)
+print(len(data["tests"]))
+EOF
+)
+
+echo "Found $num_tests tests"
+make -C .. reset
+
+
+srun -N 1 -w cnode3-001 -p <Group Name>--mpi=pmix --gres=gpu:1 --ntasks-per-node 1 \
+  --container-image /mnt/home/usr/<container>.sqsh \
+  --container-writable \
+  --container-remap-root \
+  --container-mounts=/mnt/home/usr/projects/physicsnemo:/workspace,\
+/mnt/home/usr/usr/data:/mnt/data,\
+/mnt/home/usr/<Group Name>:/mnt/ncdr \
+  --container-workdir=/workspace/dev \
+  bash -c "
+    num_tests=\$(python3 - <<'EOF'
+import yaml
+with open('test_plan.yaml') as f:
+    import yaml
+    data = yaml.safe_load(f)
+print(len(data['tests']))
+EOF
+    )
+
+    echo Found \$num_tests tests
+
+    for i in \$(seq 0 \$((num_tests-1))); do
+        echo Running test \$i
+        make run
+    done
+  "

--- a/dev/scripts/TN2.sh
+++ b/dev/scripts/TN2.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#SBATCH -J job_name            # set job name
+#SBATCH -N 1                   # number of nodes
+#SBATCH --ntasks-per-node=1    # number of tasks per node
+#SBATCH -p <Group Name>     # need partition name
+#SBATCH -w cnode3-002          # specify node
+#SBATCH -o %x.%j.out           # output log
+#SBATCH -e %x.%j.err           # error log
+#SBATCH --gpus-per-node=1      # number of GPU per node
+#SBATCH -t 7-00:00:00                      # job runtime limit
+
+echo -e "Running on hosts: $(echo $(scontrol show hostname))"
+
+num_tests=$(python3 - <<'EOF'
+import yaml
+with open("../test_plan.yaml") as f:
+    data = yaml.safe_load(f)
+print(len(data["tests"]))
+EOF
+)
+
+echo "Found $num_tests tests"
+make -C .. reset
+
+
+srun -N 1 -w cnode3-002 -p <Group Name>--mpi=pmix --gres=gpu:1 --ntasks-per-node 1 \
+  --container-image /mnt/home/usr/<container>.sqsh \
+  --container-writable \
+  --container-remap-root \
+  --container-mounts=/mnt/home/usr/projects/physicsnemo:/workspace,\
+/mnt/home/usr/usr/data:/mnt/data,\
+/mnt/home/usr/<Group Name>:/mnt/ncdr \
+  --container-workdir=/workspace/dev \
+  bash -c "
+    num_tests=\$(python3 - <<'EOF'
+import yaml
+with open('test_plan.yaml') as f:
+    import yaml
+    data = yaml.safe_load(f)
+print(len(data['tests']))
+EOF
+    )
+
+    echo Found \$num_tests tests
+
+    for i in \$(seq 0 \$((num_tests-1))); do
+        echo Running test \$i
+        make run
+    done
+  "

--- a/dev/scripts/TN3.sh
+++ b/dev/scripts/TN3.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#SBATCH -J job_name            # set job name
+#SBATCH -N 1                   # number of nodes
+#SBATCH --ntasks-per-node=1    # number of tasks per node
+#SBATCH -p <Group Name>     # need partition name
+#SBATCH -w cnode3-003          # specify node
+#SBATCH -o %x.%j.out           # output log
+#SBATCH -e %x.%j.err           # error log
+#SBATCH --gpus-per-node=1      # number of GPU per node
+#SBATCH -t 7-00:00:00                      # job runtime limit
+
+echo -e "Running on hosts: $(echo $(scontrol show hostname))"
+
+num_tests=$(python3 - <<'EOF'
+import yaml
+with open("../test_plan.yaml") as f:
+    data = yaml.safe_load(f)
+print(len(data["tests"]))
+EOF
+)
+
+echo "Found $num_tests tests"
+make -C .. reset
+
+
+srun -N 1 -w cnode3-003 -p <Group Name>--mpi=pmix --gres=gpu:1 --ntasks-per-node 1 \
+  --container-image /mnt/home/usr/<container>.sqsh \
+  --container-writable \
+  --container-remap-root \
+  --container-mounts=/mnt/home/usr/projects/physicsnemo:/workspace,\
+/mnt/home/usr/usr/data:/mnt/data,\
+/mnt/home/usr/<Group Name>:/mnt/ncdr \
+  --container-workdir=/workspace/dev \
+  bash -c "
+    num_tests=\$(python3 - <<'EOF'
+import yaml
+with open('test_plan.yaml') as f:
+    import yaml
+    data = yaml.safe_load(f)
+print(len(data['tests']))
+EOF
+    )
+
+    echo Found \$num_tests tests
+
+    for i in \$(seq 0 \$((num_tests-1))); do
+        echo Running test \$i
+        make run
+    done
+  "

--- a/dev/scripts/TN4.sh
+++ b/dev/scripts/TN4.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#SBATCH -J job_name            # set job name
+#SBATCH -N 1                   # number of nodes
+#SBATCH --ntasks-per-node=1    # number of tasks per node
+#SBATCH -p <Group Name>     # need partition name
+#SBATCH -w cnode3-004          # specify node
+#SBATCH -o %x.%j.out           # output log
+#SBATCH -e %x.%j.err           # error log
+#SBATCH --gpus-per-node=1      # number of GPU per node
+#SBATCH -t 7-00:00:00                      # job runtime limit
+
+echo -e "Running on hosts: $(echo $(scontrol show hostname))"
+
+num_tests=$(python3 - <<'EOF'
+import yaml
+with open("../test_plan.yaml") as f:
+    data = yaml.safe_load(f)
+print(len(data["tests"]))
+EOF
+)
+
+echo "Found $num_tests tests"
+make -C .. reset
+
+
+srun -N 1 -w cnode3-004 -p <Group Name>--mpi=pmix --gres=gpu:1 --ntasks-per-node 1 \
+  --container-image /mnt/home/usr/<container>.sqsh \
+  --container-writable \
+  --container-remap-root \
+  --container-mounts=/mnt/home/usr/projects/physicsnemo:/workspace,\
+/mnt/home/usr/usr/data:/mnt/data,\
+/mnt/home/usr/<Group Name>:/mnt/ncdr \
+  --container-workdir=/workspace/dev \
+  bash -c "
+    num_tests=\$(python3 - <<'EOF'
+import yaml
+with open('test_plan.yaml') as f:
+    import yaml
+    data = yaml.safe_load(f)
+print(len(data['tests']))
+EOF
+    )
+
+    echo Found \$num_tests tests
+
+    for i in \$(seq 0 \$((num_tests-1))); do
+        echo Running test \$i
+        make run
+    done
+  "

--- a/dev/scripts/hpl.sh
+++ b/dev/scripts/hpl.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_URL="${REPO_URL:-https://github.com/runberry/physicsnemo.git}"
+REPO_DIR="${REPO_DIR:-$PWD/physicsnemo}"
+BRANCH="${BRANCH:-exp/tp1}"
+
+PIP_CACHE_DIR="${PIP_CACHE_DIR:-/tmp/pipcache}"   # 加速 pip
+PYTHON_BIN="${PYTHON_BIN:-python3}"               # 或 python
+
+# 第一次才做 clone
+if [[ ! -d "$REPO_DIR/.git" ]]; then
+  git clone "$REPO_URL" "$REPO_DIR"
+fi
+
+# 避免以root執行的 safe.directory 警告
+git config --global --add safe.directory "$REPO_DIR" 2>/dev/null || true
+
+cd "$REPO_DIR"
+
+# 取最新並切分支 
+git fetch --prune origin
+
+# 若本地已存在分支就切換 否則從遠端建立 沒有則新建
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  git checkout "$BRANCH"
+else
+  if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+    git checkout -B "$BRANCH" "origin/$BRANCH"
+  else
+    git checkout -B "$BRANCH"
+  fi
+fi
+
+# 避免產生merge commit
+git pull --ff-only origin "$BRANCH" || true
+
+# install requirements
+export PIP_CACHE_DIR
+cd dev
+"$PYTHON_BIN" -m pip install --upgrade pip
+"$PYTHON_BIN" -m pip install -r requirements.txt
+cd ..
+
+# make run
+make run

--- a/dev/scripts/hpl.sh
+++ b/dev/scripts/hpl.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO_URL="${REPO_URL:-https://github.com/runberry/physicsnemo.git}"
+REPO_URL="${REPO_URL:-https://github.com/running-berry/physicsnemo.git}"
 REPO_DIR="${REPO_DIR:-$PWD/physicsnemo}"
 BRANCH="${BRANCH:-exp/tp1}"
 
@@ -41,6 +41,8 @@ cd dev
 "$PYTHON_BIN" -m pip install --upgrade pip
 "$PYTHON_BIN" -m pip install -r requirements.txt
 cd ..
+
+git checkout "feat/train-hpc-scripts"
 
 # make run
 make run

--- a/dev/scripts/temp.sh
+++ b/dev/scripts/temp.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+source .env
+#SBATCH -J job_name            # set job name
+#SBATCH -N 1                   # number of nodes
+#SBATCH --ntasks-per-node=1    # number of tasks per node
+#SBATCH -p <Group Name>     # need partition name
+#SBATCH -o %x.%j.out           # output log
+#SBATCH -e %x.%j.err           # error log
+#SBATCH --gpus-per-node=1      # number of GPU per node
+# job runtime limit
+#SBATCH -t 01:00:00
+
+HOMEDIR=/mnt/home/usr  # replace with actual home directory
+SQSH=/<container>.sqsh  # replace with actual SQSH file
+PARTITION=<Group Name> # replace with actual partition name
+NODE_ID=cnode3-003
+
+echo -e "Running on hosts: $(echo $(scontrol show hostname))"
+
+srun -N 1 -p ${PARTITION}  --mpi=pmix --gres=gpu:1 \
+    --container-image ${HOMEDIR}${SQSH} \
+    --container-writable \
+    --container-remap-root \
+    --container-mounts ${HOMEDIR}/projects/physicsnemo:/workspace \
+    bash -c "
+    cd dev
+    make run
+    "
+
+


### PR DESCRIPTION
## Description
Add Slurm job scripts for running distributed training on HPC with Enroot/Pyxis

## Changes
- Added new folder `dev/scripts/` to organize HPC job scripts
- Added `2N.sh`: Slurm job script for 2-node training job
- Added `hpl.sh`: Setup & run script (clone repo, checkout branch, install dependencies, run training)