### PR TITLE
feat: unequal vars in HighRes and LowRes

### DIFF
--- a/dev/Makefile
+++ b/dev/Makefile
@@ -4,6 +4,8 @@ data_dir := /workspace/dev/data
 rwrf_dir := /workspace/dev/rwrf-process
 log_dir := /workspace/dev/logs
 variable := t2m u10 cropped-qpepre  # List of variables to process
+var_high_res := t2m cropped-qpepre  # High resolution variables
+var_low_res := t2m  # Low resolution variables
 # variable := pptn
 
 pull:
@@ -36,9 +38,19 @@ clear_rundir:
 	rm -rf $(stormcast_dir)/rundir
 
 make_cache:
-	for variable in $(variable); do \
+	for variable in $(var_high_res); do \
 		cd $(rwrf_dir) && \
-		$(MAKE) nc-to-npz-$$variable; \
+		if [ "$$variable" = "cropped-qpepre" ]; then \
+			python combine_rwrf_qpepre.py && \
+			python fetch_rwrf.py --variable pptn --cropped-qpepre; \
+		else \
+			python fetch_rwrf.py --variable $$variable; \
+		fi \
+	done
+
+	for variable in $(var_low_res); do \
+		cd $(rwrf_dir) && \
+		python fetch_era5.py --variable $$variable; \
 	done
 
 run:

--- a/dev/rwrf-process/create_data.py
+++ b/dev/rwrf-process/create_data.py
@@ -9,8 +9,11 @@ import yaml
 with open("../../examples/weather/stormcast/config/dataset/small.yaml", "r") as f:
     cfg = yaml.safe_load(f)
 
-channel_vars = ["t2m"]
-channel_vars = ["pptn"]
+channel_vars = {
+    "LowRes": ["t2m"],
+    "HighRes": ["t2m", "pptn"],
+    "dummy": "t2m",
+}
 num_channel = len(channel_vars)
 domain_size = tuple(cfg["HighRes_img_size"])
 test_datetime_start = cfg["train_dates"][0]
@@ -93,7 +96,7 @@ for fname in ["HighRes", "LowRes"]:
     dummy_data, dummy_lon_grid, dummy_lat_grid, dummy_times = create_dummy_arr(
         datetime_array[0],
         cache_path,
-        channel_vars[0],
+        channel_vars["dummy"],
         lon_min,
         lon_max,
         lat_min,
@@ -103,7 +106,7 @@ for fname in ["HighRes", "LowRes"]:
     data_arr = None
     for dt in datetime_array:
         channel_arr = None
-        for var in channel_vars:
+        for var in channel_vars[fname]:
             yy, mm, dd, hh = (
                 np.datetime_as_string(dt, unit="h").replace("T", "-").split("-")
             )
@@ -177,7 +180,7 @@ for fname in ["HighRes", "LowRes"]:
         {
             f"{fname}": (["time", "channel", "y", "x"], data_arr),
             "time": datetime_array,
-            "channel": channel_vars,
+            "channel": channel_vars[fname],
             "latitude": (["y", "x"], lat_grid),
             "longitude": (["y", "x"], lon_grid),
         }


### PR DESCRIPTION
## Types of changes
- **New Feature**

## Description
Enable **imbalanced** variable sets between HighRes and LowRes (remove 1:1 constraint). Example: HighRes includes `pptn` while LowRes stays `t2m` only.

## Changes
### dev/Makefile
```make
var_high_res := t2m cropped-qpepre
var_low_res  := t2m
```
In `make_cache`:
- For `cropped-qpepre`: run `combine_rwrf_qpepre.py`, then:
  ```bash
  python fetch_rwrf.py --variable pptn --cropped-qpepre
  ```
- Fetch ERA5 only for `var_low_res`.

### dev/rwrf-process/create_data.py
```python
channel_vars = {
    "LowRes":  ["t2m"],
    "HighRes": ["t2m", "pptn"],
    "dummy":   "t2m",
}
# use channel_vars["dummy"] for dummy arrays
# loop per file with channel_vars[fname]
# write per-file 'channel' coord
```

## Steps to Test
1. `cd dev`
2. `make make_cache && make run`
3. Verify outputs:
   - HighRes channels: `["t2m", "pptn"]`
   - LowRes channels: `["t2m"]`
