### PR TITLE
refactor: grib to nc

### DIFF
--- a/dev/data/grib2nc.py
+++ b/dev/data/grib2nc.py
@@ -13,6 +13,14 @@ import xarray as xr
 import pygrib
 from netCDF4 import Dataset, date2num
 import calendar
+import warnings
+
+var_standard_name = {
+    't2m': 'air_temperature',
+    'u10': 'eastward_wind',
+    'v10': 'northward_wind',
+    'msl': 'air_pressure_at_mean_sea_level'
+}
 
 def grib_to_netcdf_pygrib(grib_file, output_file=None, compression=True):
     """
@@ -322,9 +330,244 @@ class GribToNetCDFConverter:
         self.method = method
         self.compression = compression
     
+    def grib_to_netcdf_pygrib(self, grib_path, nc_path, compression=True):
+        """
+        Convert GRIB file to NetCDF using pygrib
+        
+        Args:
+            grib_file (str): Path to input GRIB file
+            output_file (str): Path to output NetCDF file (optional)
+            compression (bool): Whether to compress the output file
+        """  
+        if not nc_path:
+            base_name = os.path.splitext(grib_path)[0]
+            nc_path = f"{base_name}.nc"
+        
+        self.output_file = nc_path
+        print(f"Converting {grib_path} to {nc_path} using pygrib")
+        
+        filename, var_name, dt, timestamp= self.get_info_from_filename(grib_path)
+        #try:
+            # Open GRIB file
+        with pygrib.open(grib_path) as grbs:
+            # Analyze all messages to get dimensions and variables
+            variables_data = {} 
+            for i, grb in enumerate(grbs, 1):
+                print(f"Processing message {i}: {grb}")
+                # Store dimensions and global attributes from fist message
+                if i == 1:
+                    lats, lons, data, units, long_name = \
+                        self.get_info_from_grib(grb, var_name)
+
+                    dimensions = self._get_dimensions(
+                        grb, 
+                        lats,
+                        lons, 
+                        timestamp
+                    )
+                    try:
+                        global_attrs = self._get_global_attributes(
+                            grb,
+                            dt,
+                            grib_path
+                        )
+                    except:
+                        pass
+            
+                # Store variable data                        
+                variables_data, clean_var_name = self._get_variables(
+                    grb,
+                    variables_data,
+                    var_name, 
+                    data,
+                    units,
+                    long_name,
+                    timestamp
+                )
+        
+        # Create NetCDF file
+        print(f"Writing NetCDF file: {nc_path}")
+        print(f"Variable: {clean_var_name}, Time: {dt}") 
+
+        with Dataset(self.output_file, 'w', format='NETCDF4') as nc:
+            self._store_dimensions(nc, dimensions)
+            self._store_coordinates(nc, dimensions)
+            self._store_variables(nc, variables_data, clean_var_name)
+            self._store_global_attributes(nc, global_attrs)
+
+        print(f"Successfully converted {grib_path} to {nc_path}")
+        return nc_path
+
+        #except Exception as e:
+        #    print(f"Error converting {grib_path}: {e}")
+        #    return None
+
+    def get_info_from_filename(self, grib_fn):
+        """
+        Extract variable name and time from GRIB filename
+        
+        Args:
+            grib_file (str): Path to input GRIB file
+            
+        Returns:
+            tuple: (filename, datetime object, timestamp)
+        """
+        # Extract variable name and time from filename
+        filename = os.path.basename(grib_fn)
+        base_name = os.path.splitext(filename)[0]
+        
+        # Parse filename format: variable_YYYYMMDDHH.grib
+        try:
+            parts = base_name.split('_')
+            if len(parts) >= 2:
+                var_name = parts[0]
+                datetime_str = parts[1]
+                
+                # Parse datetime: YYYYMMDDHH
+                if len(datetime_str) == 10:  # YYYYMMDDHH
+                    dt = datetime.strptime(datetime_str, "%Y%m%d%H")
+                else:
+                    raise ValueError("Invalid datetime format")
+            else:
+                raise ValueError("Invalid filename format")
+        except:
+            print(f"Warning: Could not parse filename {filename}, using defaults")
+            var_name = "unknown_var"
+            dt = datetime(1970, 1, 1)
+        
+        # Convert to timestamp
+        timestamp = calendar.timegm(dt.timetuple())
+        
+        return filename, dt, var_name, timestamp
+    
+    def get_info_from_grib(self, grb, var_name):
+        var_info = {}
+        # Get grid data
+        lats, lons = grb.latlons()
+        data = grb.values
+        
+        # Get units and long name from GRIB, but use filename for variable name
+        try:
+            units = grb.get('units', '')
+            long_name = grb.get('name', var_name)
+        except:
+            units = ''
+            long_name = var_name
+
+        return lats, lons, data, units, long_name
+    
+    def _get_variables(self, grb, variables_data, var_name, data, units, long_name, timestamp): 
+        # Use variable name from filename
+        clean_var_name = var_name.replace(' ', '_').replace('-', '_')
+        if clean_var_name[0].isdigit():
+            clean_var_name = f"var_{clean_var_name}"
+        
+        # Store variable data
+        variables_data[clean_var_name] = {
+                'data': data,
+                'units': units,
+                'long_name': long_name,
+                'dimensions': ('latitude', 'longitude'),
+                'time': timestamp
+            }
+
+        return variables_data, clean_var_name
+
+    def _get_dimensions(self, grb, lats, lons, timestamp):
+        dimensions = {}
+        # Store dimensions (assuming all messages have same grid)
+        if 'latitude' not in dimensions:
+            dimensions['latitude'] = lats[:, 0]  # First column
+            dimensions['longitude'] = lons[0, :]  # First row                
+            dimensions['valid_time'] = [timestamp]
+        
+        return dimensions
+
+    def _get_global_attributes(self, grb, dt, grib_file):
+        global_attrs = {}
+        global_attrs.update({
+            'source': 'ERA5',
+            'institution': 'ECMWF',
+            'created': datetime.now().isoformat(),
+            'original_file': os.path.basename(grib_file),
+            'grid_type': grb.get('gridType', 'unknown'),
+            'data_date': dt.strftime("%Y-%m-%d"),
+            'data_time': dt.strftime("%H:%M:%S")
+        })
+
+        return global_attrs
+    
+    def _store_dimensions(self, nc, dimensions):
+        nc.createDimension('valid_time', len(dimensions['valid_time']))
+        nc.createDimension('latitude', len(dimensions['latitude']))
+        nc.createDimension('longitude', len(dimensions['longitude']))
+        
+        # Add scalar dimension for ensemble member (like in your ERA5 data)
+        nc.createDimension('number', 1)
+
+    def _store_coordinates(self, nc, dimensions):
+        # Time
+        time_var = nc.createVariable('valid_time', 'i8', ('valid_time',), 
+                                   zlib=self.compression)
+        time_var[:] = dimensions['valid_time']
+        time_var.units = 'seconds since 1970-01-01'
+        time_var.long_name = 'time'
+        time_var.standard_name = 'time'
+        
+        # Latitude
+        lat_var = nc.createVariable('latitude', 'f8', ('latitude',), 
+                                  zlib=self.compression)
+        lat_var[:] = dimensions['latitude']
+        lat_var.units = 'degrees_north'
+        lat_var.long_name = 'latitude'
+        lat_var.standard_name = 'latitude'
+        
+        # Longitude
+        lon_var = nc.createVariable('longitude', 'f8', ('longitude',), 
+                                  zlib=self.compression)
+        lon_var[:] = dimensions['longitude']
+        lon_var.units = 'degrees_east'
+        lon_var.long_name = 'longitude'
+        lon_var.standard_name = 'longitude'
+        
+        # Ensemble number (to match ERA5 format)
+        number_var = nc.createVariable('number', 'i8', (), zlib=self.compression)
+        number_var[()] = 0
+        number_var.units = '1'
+        number_var.long_name = 'ensemble member numerical id'
+
+    def _store_variables(self, nc, variables_data, clean_var_name):
+        # Create data variables
+        for var_name_key, var_info in variables_data.items():
+            data_var = nc.createVariable(
+                var_name_key, 'f4', 
+                ('valid_time', 'latitude', 'longitude'),
+                zlib=self.compression,
+                complevel=6 if self.compression else 0
+            )
+            
+            # Reshape data to match dimensions
+            data_var[0, :, :] = var_info['data']
+            data_var.units = var_info['units']
+            data_var.long_name = var_info['long_name']
+            
+            # Add coordinates attribute to reference the number coordinate
+            data_var.coordinates = 'number'
+
+            # Add standard names based on variable name
+            data_var.standard_name = var_standard_name[var_name_key.lower()]
+
+    def _store_global_attributes(self, nc, global_attrs):
+        for attr_name, attr_value in global_attrs.items():
+            setattr(nc, attr_name, attr_value)
+        
+        # Add standard global attributes
+        nc.Conventions = 'CF-1.8'
+        nc.title = f"Converted from {os.path.basename(self.input_path)}"
+    
     def convert(self):
         if os.path.isfile(self.input_path):
-            return grib_to_netcdf_pygrib(self.input_path, self.output_path, self.compression) \
+            return self.grib_to_netcdf_pygrib(self.input_path, self.output_path, self.compression) \
                 if self.method == 'pygrib' else grib_to_netcdf_xarray(self.input_path, self.output_path, self.compression)
         elif os.path.isdir(self.input_path):
             return convert_directory(self.input_path, self.output_path, pattern="*.grib", method=self.method, compression=self.compression)

--- a/dev/data/grib2nc.py
+++ b/dev/data/grib2nc.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Convert GRIB files to NetCDF format
 Handles ERA5 data and maintains proper dimensions and metadata
@@ -13,6 +12,7 @@ import numpy as np
 import xarray as xr
 import pygrib
 from netCDF4 import Dataset, date2num
+import calendar
 
 def grib_to_netcdf_pygrib(grib_file, output_file=None, compression=True):
     """
@@ -53,7 +53,6 @@ def grib_to_netcdf_pygrib(grib_file, output_file=None, compression=True):
         dt = datetime(1970, 1, 1)
     
     # Convert to timestamp
-    import calendar
     timestamp = calendar.timegm(dt.timetuple())
     
     try:
@@ -311,7 +310,28 @@ def convert_directory(input_dir, output_dir=None, pattern="*.grib", method="pygr
     
     print(f"\nConversion complete: {converted} successful, {failed} failed")
 
-def main():
+class GribToNetCDFConverter:
+    """
+    Class to handle GRIB to NetCDF conversion
+    Can be extended for more methods or configurations in the future
+    """
+    
+    def __init__(self, input_path, output_path=None, method='pygrib', compression=True):
+        self.input_path = input_path
+        self.output_path = output_path
+        self.method = method
+        self.compression = compression
+    
+    def convert(self):
+        if os.path.isfile(self.input_path):
+            return grib_to_netcdf_pygrib(self.input_path, self.output_path, self.compression) \
+                if self.method == 'pygrib' else grib_to_netcdf_xarray(self.input_path, self.output_path, self.compression)
+        elif os.path.isdir(self.input_path):
+            return convert_directory(self.input_path, self.output_path, pattern="*.grib", method=self.method, compression=self.compression)
+        else:
+            raise ValueError(f"Invalid input path: {self.input_path}")
+
+def parse_grib2nc_args():
     parser = argparse.ArgumentParser(description='Convert GRIB files to NetCDF format')
     parser.add_argument('input', help='Input GRIB file or directory')
     parser.add_argument('-o', '--output', help='Output NetCDF file or directory')
@@ -323,25 +343,14 @@ def main():
                        help='Disable compression in output NetCDF files')
     parser.add_argument('-v', '--verbose', action='store_true',
                        help='Verbose output')
-    
     args = parser.parse_args()
-    
-    compression = not args.no_compression
-    
-    if os.path.isfile(args.input):
-        # Single file conversion
-        if args.method == 'pygrib':
-            grib_to_netcdf_pygrib(args.input, args.output, compression)
-        else:
-            grib_to_netcdf_xarray(args.input, args.output, compression)
-    
-    elif os.path.isdir(args.input):
-        # Directory conversion
-        convert_directory(args.input, args.output, args.pattern, args.method, compression)
-    
-    else:
-        print(f"Error: '{args.input}' is not a valid file or directory")
-        sys.exit(1)
+    args.compression = not args.no_compression
+    return args
 
+def main():
+    args = parse_grib2nc_args()
+    grib_converter = GribToNetCDFConverter(args.input, args.output, args.method, args.compression)
+    grib_converter.convert()
+    
 if __name__ == "__main__":
     main()

--- a/dev/data/grib2nc.py
+++ b/dev/data/grib2nc.py
@@ -346,7 +346,7 @@ class GribToNetCDFConverter:
         self.output_file = nc_path
         print(f"Converting {grib_path} to {nc_path} using pygrib")
         
-        filename, var_name, dt, timestamp= self.get_info_from_filename(grib_path)
+        filename, dt, var_name, timestamp= self._get_info_from_filename(grib_path)
         #try:
             # Open GRIB file
         with pygrib.open(grib_path) as grbs:
@@ -357,32 +357,13 @@ class GribToNetCDFConverter:
                 # Store dimensions and global attributes from fist message
                 if i == 1:
                     lats, lons, data, units, long_name = \
-                        self.get_info_from_grib(grb, var_name)
-
-                    dimensions = self._get_dimensions(
-                        grb, 
-                        lats,
-                        lons, 
-                        timestamp
-                    )
-                    try:
-                        global_attrs = self._get_global_attributes(
-                            grb,
-                            dt,
-                            grib_path
-                        )
-                    except:
-                        pass
+                        self._get_info_from_grib(grb, var_name)
+                    dimensions = self._get_dimensions( grb, lats, lons, timestamp)
+                    global_attrs = self._get_global_attributes(grb, dt, grib_path)
             
                 # Store variable data                        
                 variables_data, clean_var_name = self._get_variables(
-                    grb,
-                    variables_data,
-                    var_name, 
-                    data,
-                    units,
-                    long_name,
-                    timestamp
+                    grb, variables_data, var_name, data, units, long_name, timestamp
                 )
         
         # Create NetCDF file
@@ -402,7 +383,7 @@ class GribToNetCDFConverter:
         #    print(f"Error converting {grib_path}: {e}")
         #    return None
 
-    def get_info_from_filename(self, grib_fn):
+    def _get_info_from_filename(self, grib_fn):
         """
         Extract variable name and time from GRIB filename
         
@@ -419,13 +400,16 @@ class GribToNetCDFConverter:
         # Parse filename format: variable_YYYYMMDDHH.grib
         try:
             parts = base_name.split('_')
+            var_name = parts[0]
+
             if len(parts) >= 2:
-                var_name = parts[0]
-                datetime_str = parts[1]
-                
-                # Parse datetime: YYYYMMDDHH
-                if len(datetime_str) == 10:  # YYYYMMDDHH
-                    dt = datetime.strptime(datetime_str, "%Y%m%d%H")
+                if len(parts[1]) == 10: 
+                    # Format: variable_YYYYMMDDHH.grib
+                    dt = datetime.strptime(parts[1], "%Y%m%d%H")
+
+                elif len(parts) >= 3 and len(parts[1]) == 8 and len(parts[2]) == 2:
+                    # Format: variable_YYYYMMDD_HH.grib
+                    dt = datetime.strptime(parts[1] + parts[2], "%Y%m%d%H")
                 else:
                     raise ValueError("Invalid datetime format")
             else:
@@ -437,10 +421,11 @@ class GribToNetCDFConverter:
         
         # Convert to timestamp
         timestamp = calendar.timegm(dt.timetuple())
+        print("var_name:", var_name)
         
         return filename, dt, var_name, timestamp
     
-    def get_info_from_grib(self, grb, var_name):
+    def _get_info_from_grib(self, grb, var_name):
         var_info = {}
         # Get grid data
         lats, lons = grb.latlons()
@@ -458,10 +443,7 @@ class GribToNetCDFConverter:
     
     def _get_variables(self, grb, variables_data, var_name, data, units, long_name, timestamp): 
         # Use variable name from filename
-        clean_var_name = var_name.replace(' ', '_').replace('-', '_')
-        if clean_var_name[0].isdigit():
-            clean_var_name = f"var_{clean_var_name}"
-        
+        clean_var_name = var_name
         # Store variable data
         variables_data[clean_var_name] = {
                 'data': data,
@@ -470,6 +452,7 @@ class GribToNetCDFConverter:
                 'dimensions': ('latitude', 'longitude'),
                 'time': timestamp
             }
+        print(f"clean_var_name:{clean_var_name}")
 
         return variables_data, clean_var_name
 
@@ -490,7 +473,7 @@ class GribToNetCDFConverter:
             'institution': 'ECMWF',
             'created': datetime.now().isoformat(),
             'original_file': os.path.basename(grib_file),
-            'grid_type': grb.get('gridType', 'unknown'),
+            'grid_type': grb.gridType,
             'data_date': dt.strftime("%Y-%m-%d"),
             'data_time': dt.strftime("%H:%M:%S")
         })
@@ -567,6 +550,7 @@ class GribToNetCDFConverter:
     
     def convert(self):
         if os.path.isfile(self.input_path):
+            #return grib_to_netcdf_pygrib(self.input_path, self.output_path, self.compression) \
             return self.grib_to_netcdf_pygrib(self.input_path, self.output_path, self.compression) \
                 if self.method == 'pygrib' else grib_to_netcdf_xarray(self.input_path, self.output_path, self.compression)
         elif os.path.isdir(self.input_path):

--- a/dev/data/test_grib2nc.py
+++ b/dev/data/test_grib2nc.py
@@ -1,0 +1,97 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from datetime import datetime
+import calendar
+import numpy as np
+
+# Import the function under test
+from grib2nc import grib_to_netcdf_pygrib
+
+
+class DummyGrib:
+    def __init__(self):
+        self.values = [[1, 2], [3, 4]]
+    
+    def latlons(self):
+        lats = np.array([[10, 10], [20, 20]])
+        lons = np.array([[30, 40], [30, 40]])
+        return lats, lons
+
+    def get(self, key, default=None):
+        if key == 'units':
+            return 'K'
+        if key == 'name':
+            return 'Temperature'
+        if key == 'gridType':
+            return 'regular_ll'
+        return default
+
+    def __str__(self):
+        return "DummyGrib message"
+
+
+@pytest.fixture
+def mock_pygrib_open():
+    class DummyGribFile:
+        def __init__(self, msgs):
+            self._msgs = msgs
+            self.closed = False
+        # iterable
+        def __iter__(self):
+            return iter(self._msgs)
+        # close-able
+        def close(self):
+            self.closed = True
+        # context-manager compatible
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            self.close()
+            return False  # don’t suppress exceptions
+
+    with patch("grib2nc.pygrib.open", autospec=True) as mock_open:
+        mock_open.return_value = DummyGribFile([DummyGrib()])
+        yield mock_open
+
+
+@pytest.fixture
+def mock_netcdf_dataset():
+    with patch("grib2nc.Dataset") as mock_ds:
+        mock_nc = MagicMock()
+        mock_ds.return_value.__enter__.return_value = mock_nc
+        yield mock_ds
+
+
+def test_grib_to_netcdf_success(tmp_path, mock_pygrib_open, mock_netcdf_dataset):
+    grib_file = tmp_path / "t2m_2025010100.grib"
+    grib_file.write_text("dummy content")  # create fake file
+
+    output = grib_to_netcdf_pygrib(str(grib_file))
+
+    assert output.endswith(".nc")
+    mock_pygrib_open.assert_called_once_with(str(grib_file))
+    mock_netcdf_dataset.assert_called_once()
+
+
+def test_grib_to_netcdf_bad_filename(tmp_path, mock_pygrib_open, mock_netcdf_dataset):
+    grib_file = tmp_path / "invalidname.grib"
+    grib_file.write_text("dummy content")
+
+    output = grib_to_netcdf_pygrib(str(grib_file))
+
+    assert output.endswith(".nc")
+    mock_pygrib_open.assert_called_once()
+    mock_netcdf_dataset.assert_called_once()
+
+
+def test_grib_to_netcdf_exception(tmp_path):
+    grib_file = tmp_path / "t2m_2025010100.grib"
+    grib_file.write_text("dummy content")
+
+    # Force pygrib.open to raise an exception
+    with patch("grib2nc.pygrib.open", side_effect=RuntimeError("cannot open")), \
+         patch("grib2nc.Dataset") as mock_nc:
+        output = grib_to_netcdf_pygrib(str(grib_file))
+
+    # Should return None on failure
+    assert output is None


### PR DESCRIPTION
## Description  
Refactor `feat/grib2nc` to improve modularity and readability of grib2nc.py

## Steps to Test  
1. Run unit tests:  
   ```bash
   pytest grib2nc.py
   ```  
2. Run the script directly (same usage as before):  
   ```bash
   python grib2nc.py <Path>/data/era5_grib/t2m_20190803_00.grib

## New Changes  
1. Introduced `GribToNetCDFConverter` class to simplify and clean up the main function.  
2. Added `parse_grib2nc_args()` for clearer CLI argument handling.  
3. Integrated `grib_to_netcdf_pygrib` into `GribToNetCDFConverter` and refactored the process into atomic methods (e.g., `_get`, `_store`).  
4. Added `test_grib2nc` to validate that the new class produces equivalent results to the legacy `grib_to_netcdf_pygrib` function.  

## In Progress
1. Unequal nc file generated from grib2nc.py and original nc file downloaded from TWCC.
2. Refactor `grib_to_netcdf_xarray`
3. Refactor `convert_directory`