### PR TITLE
fix: parse era5 pressure vars

### DIFF
--- a/dev/rwrf_process/datasource/era5.py
+++ b/dev/rwrf_process/datasource/era5.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import pathlib
+import re
 
 import nest_asyncio
 import netCDF4 as nc
@@ -97,6 +98,10 @@ class ERA5:
                 ds.close()
                 return
             variable = parts[0]
+            # parse variable if kind of pressure levels
+            pressure_level_pattern = r"^(u|v|z|t|q)(\d+)$"
+            if variable != "u10" and re.match(pressure_level_pattern, variable):
+                variable = "pressure_level"
             date_str = parts[1]
 
             for key in ["latitude", "longitude", "valid_time", variable]:
@@ -109,8 +114,11 @@ class ERA5:
             lon = ds.variables["longitude"][:]
             times = ds.variables["valid_time"][:]
             data = ds.variables[variable][:]
+            # revert variable name if needed for saving .npz
             if variable == "tp":
                 variable = "qpepre"
+            else:
+                variable = parts[0]
 
         except Exception as e:
             logger.error(f"Error processing file {nc_path}: {e}")

--- a/dev/rwrf_process/datasource/era5.py
+++ b/dev/rwrf_process/datasource/era5.py
@@ -100,7 +100,11 @@ class ERA5:
             variable = parts[0]
             # parse variable if kind of pressure levels
             pressure_level_pattern = r"^(u|v|z|t|q)(\d+)$"
-            if variable != "u10" and re.match(pressure_level_pattern, variable):
+            if (
+                variable != "u10"
+                and variable != "v10"
+                and re.match(pressure_level_pattern, variable)
+            ):
                 variable = "pressure_level"
             date_str = parts[1]
 


### PR DESCRIPTION
This pull request updates the `convert_to_npz` method in `era5.py` to improve the way variable names are parsed and handled, especially for pressure level variables. The changes ensure that variable names are correctly interpreted and reverted when saving data, which helps maintain consistency and prevent errors.

**Improvements to variable parsing and handling:**

* Added a regular expression to detect pressure level variables and standardize their naming to `"pressure_level"` during processing, except for `"u10"` and `"v10"` which are handled separately.
* Ensured that the original variable name is restored before saving to `.npz` files, except when the variable is `"tp"`, which is mapped to `"qpepre"` for output consistency.

**Codebase maintenance:**

* Imported the `re` module to support regular expression matching for variable name parsing.