### PR TITLE
Feat: Enabling Validation during training

### DIFF
--- a/dev/rwrf_process/config.yaml
+++ b/dev/rwrf_process/config.yaml
@@ -1,7 +1,10 @@
 dataset_paths:
-  rwrf: "../data/rwrf"
-  era5: "../data/era5/train"
+  rwrf: "/workspace/NCDR_StormCast/data/RWRF"
+  era5: "/workspace/NCDR_StormCast/era5"
   qpepre: "../data/pptn"
+  era5_npz: "/workspace/NCDR_StormCast/era5_npz/"
+  rwrf_npz: "/workspace/NCDR_StormCast/rwrf_npz/"
+
 
 # dates for dataset
 date_strs: ["2019/08/03"]

--- a/dev/rwrf_process/create_data.py
+++ b/dev/rwrf_process/create_data.py
@@ -1,4 +1,7 @@
 import os
+import logging
+import sys
+from datetime import datetime
 
 import numpy as np
 import util_extract as u1
@@ -6,11 +9,43 @@ import xarray as xr
 import yaml
 import zarr
 
+# Configure logging
+def setup_logger():
+    """Setup logger with timestamp and process information."""
+    logger = logging.getLogger(__name__)
+    
+    # Remove existing handlers to avoid duplicates
+    for handler in logger.handlers[:]:
+        logger.removeHandler(handler)
+    
+    # Create formatter
+    formatter = logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    )
+    
+    # Console handler
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setFormatter(formatter)
+    logger.addHandler(console_handler)
+    
+    # File handler
+    log_file = f"create_data_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
+    file_handler = logging.FileHandler(log_file)
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+    
+    logger.info(f"Logging initialized. Log file: {log_file}")
+    return logger
+
+logger = setup_logger()
+
 with open("../../examples/weather/stormcast/config/dataset/small.yaml", "r") as f:
     cfg = yaml.safe_load(f)
 
 channel_vars = {
-    "LowRes": ["t2m"],
+    "LowRes":["t2m", "u10", "pptn", "t1000", "t925", "u1000", \
+             "u200", "u250", "u500", "u700", "u850", "u925", \
+             "v10", "v1000", "v200", "v250", "v500", "v700", "v850", "v925"],
     "HighRes": ["t2m", "u10", "qpepre"],
     "dummy": "t2m",
 }
@@ -19,9 +54,12 @@ lon_min, lon_max = 121.00, 125.00
 lat_min, lat_max = 21.00, 25.00
 num_channel = len(channel_vars)
 domain_size = tuple(cfg["HighRes_img_size"])
-test_datetime_start = cfg["train_dates"][0]
-test_datetime_last = cfg["train_dates"][-1]
-cache_base = "../data/cache"
+train_datetime_start = cfg["train_dates"][0]
+train_datetime_last = cfg["train_dates"][-1]
+valid_datetime_start = cfg["valid_dates"][0]
+valid_datetime_last = cfg["valid_dates"][-1]
+
+cache_base = "/workspace/physicsnemo/dev/rwrf_process/cache"
 data_base = "../data"
 experiment_name = cfg["exp_train_zarrs"][0]
 
@@ -40,10 +78,14 @@ def create_dummy_arr(
     of the real data for timestamp dt, and also return the lon/lat grids
     and time coords.
     """
+    logger.debug(f"Creating dummy array for {data_var} at {dt}")
+
     # build the filename for this dt
     yy, mm, dd, hh = np.datetime_as_string(dt, unit="h").replace("T", "-").split("-")
-    fn = f"{data_var}_{yy}{mm}{dd}{hh}.npz"
+    fn = f"{data_var}_{yy}{mm}{dd}_{hh}.npz"
     dt_path = os.path.join(data_path, fn)
+
+    logger.debug(f"Using template file: {dt_path}")
 
     # grab one real sample to infer shapes
     real_arr, lon_grid, lat_grid, times = u1.extract_region(
@@ -60,6 +102,7 @@ def create_dummy_arr(
     Ny_tgt, Nx_tgt = domain_size
 
     if Ny_full < Ny_tgt or Nx_full < Nx_tgt:
+        logger.debug(f"Interpolating from {Ny_full}x{Nx_full} to {Ny_tgt}x{Nx_tgt}")
         real_arr, lon_grid, lat_grid = u1.interp_to_domain(
             lon_grid, lat_grid, real_arr, domain_size, method="linear"
         )
@@ -68,50 +111,168 @@ def create_dummy_arr(
         real_arr, fill_value=0.0
     )  # future: or use fill_value=np.nan
 
+    logger.debug(f"Dummy array created with shape: {dummy_arr.shape}")
+
     return dummy_arr, lon_grid, lat_grid, times
 
 
-for fname in ["HighRes", "LowRes"]:
+def process_invariants(
+    cache_base: str,
+    data_base: str,
+    experiment_name: str,
+    start_date: str,
+):
+    """
+    Process invariant data (land-sea mask, orography) and save to zarr.
+    """
+    logger.info("=" * 50)
+    logger.info("PROCESSING INVARIANTS")
+    logger.info("=" * 50)
+    
+    # Create invariants directory
+    invariant_folder = f"{data_base}/invariants"
+    os.makedirs(invariant_folder, exist_ok=True)
+    logger.info(f"Created invariants directory: {invariant_folder}")
+    
+    # Use rwrf cache path for invariants
+    cache_path = f"{cache_base}/rwrf/"
+    logger.info(f"Using cache path: {cache_path}")
+
+    # Use first datetime to get invariant data
+    base_date = np.datetime64(start_date.replace("/", "-") + "T00:00:00")
+    dt = base_date
+    logger.info(f"Using reference date: {dt}")
+
+    invariant_arr = None
+    lon_grid = None
+    lat_grid = None
+    
+    for var in invariants:
+        logger.info(f"Processing invariant {i+1}/{len(invariants)}: {var}")
+        yy, mm, dd, hh = np.datetime_as_string(dt, unit="h").replace("T", "-").split("-")
+        dt_path = os.path.join(cache_path, f"{var}_{yy}{mm}{dd}{hh}.npz")
+        print(f"Processing invariant: {dt_path}")
+
+        try:
+            dt_data, lon_grid, lat_grid, times = u1.extract_region(
+                dt_path,
+                var,
+                lon_min,
+                lon_max,
+                lat_min,
+                lat_max,
+                domain_size=domain_size,
+            )  # (1, Ny, Nx)
+            dt_data, lon_grid, lat_grid = u1.interp_to_domain(
+                lon_grid, lat_grid, dt_data, domain_size, method="linear"
+            )  # (1, Ny, Nx)
+            logger.debug(f"Successfully loaded {var} with shape: {dt_data.shape}")
+
+        except FileNotFoundError:
+            logger.error(f"Invariant file not found: {dt_path}")
+            raise FileNotFoundError(f"Invariant file not found: {dt_path}")
+
+        # concatenate data
+        if invariant_arr is None:  # first iteration only
+            invariant_arr = dt_data.copy()
+            logger.debug(f"Initialized invariant array with shape: {invariant_arr.shape}")
+        else:
+            # concatenate along axis=0 (channel)
+            invariant_arr = np.concatenate((invariant_arr, dt_data), axis=0)
+            logger.debug(f"Concatenated invariant array, new shape: {invariant_arr.shape}")
+
+    # Create xarray dataset for invariants
+    year_data = xr.Dataset(
+        {
+            "HighRes_invariants": (["channel", "y", "x"], invariant_arr),
+            "channel": invariants,
+            "latitude": (["y", "x"], lat_grid),
+            "longitude": (["y", "x"], lon_grid),
+        }
+    )
+    data_enc = {"HighRes_invariants": {"dtype": "float32", "compressor": None}}
+    logger.info(f"Final invariant array shape: {invariant_arr.shape}")
+    logger.info(f"Invariant variables: {invariants}")
+
+    # Save invariants
+    year_data.to_zarr(
+        f"{data_base}/invariants/invariants.zarr",
+        mode="w",
+        consolidated=True,
+        encoding=data_enc,
+        zarr_format=2,
+    )
+    zarr.consolidate_metadata(f"{data_base}/invariants/invariants.zarr")
+
+    print(f"Invariants saved to {data_base}/invariants/invariants.zarr")
+
+
+def process_period(
+    start_date: str,
+    end_date: str,
+    fname: str,
+    channel_vars_dict: dict,
+    cache_base: str,
+    data_base: str,
+    domain_size: tuple,
+    experiment_name: str,
+    is_validation: bool = False,
+):
+    """
+    Process a period (train or validation) and write stats + zarr.
+    start_date/end_date: strings "YYYY/MM/DD" (end_date inclusive).
+    fname: "HighRes" or "LowRes"
+    channel_vars_dict: dict with channel variables for each resolution
+    """
+
+    period_type = "VALIDATION" if is_validation else "TRAINING"
+    logger.info("=" * 50)
+    logger.info(f"PROCESSING {period_type} DATA - {fname}")
+    logger.info("=" * 50)
+    logger.info(f"Period: {start_date} to {end_date}")
+    logger.info(f"Variables: {channel_vars_dict[fname]}")
+    
     folder_path = f"{data_base}/{fname}/stats"
-    if not os.path.exists(folder_path):
-        os.makedirs(folder_path)
-    else:
-        print(f"'{folder_path}' exists, skipping stats folder generation.")
+    os.makedirs(folder_path, exist_ok=True)
+    logger.info(f"Created stats directory: {folder_path}")
 
     # determine data path base
-    if fname == "HighRes":
-        cache_path = f"{cache_base}/rwrf/train/"
-    elif fname == "LowRes":
-        cache_path = f"{cache_base}/era5/train/"
+    cache_path = f"{cache_base}/rwrf/" if fname == "HighRes" else f"{cache_base}/era5/"
+    logger.info(f"Using cache path: {cache_path}")
 
-
-    base_date = np.datetime64(test_datetime_start.replace("/", "-") + "T00:00:00")
-    end_date = np.datetime64(test_datetime_last.replace("/", "-")) + np.timedelta64(
-        23, "h"
-    )
-    total_hours = int((end_date - base_date) / np.timedelta64(1, "h")) + 1
+    base_date = np.datetime64(start_date.replace("/", "-") + "T00:00:00")
+    end_date_np = np.datetime64(end_date.replace("/", "-")) + np.timedelta64(23, "h")
+    total_hours = int((end_date_np - base_date) / np.timedelta64(1, "h")) + 1
     offsets = np.arange(total_hours, dtype=np.int64)
     datetime_array = base_date + offsets * np.timedelta64(1, "h")
-    print(cache_path)
+
+    logger.info(f"Processing {total_hours} hourly time steps")
+
     # create the dummy data format by the first data
+    logger.info("Creating dummy data template...")
+
     dummy_data, dummy_lon_grid, dummy_lat_grid, dummy_times = create_dummy_arr(
         datetime_array[0],
         cache_path,
-        channel_vars["dummy"],
+        channel_vars_dict["dummy"],
         lon_min,
         lon_max,
         lat_min,
         lat_max,
     )
+
     missing_data = []
     data_arr = None
+    processed_files = 0
+    missing_files = 0
+
     for dt in datetime_array:
         channel_arr = None
-        for var in channel_vars[fname]:
+        for var in channel_vars_dict[fname]:
             yy, mm, dd, hh = (
                 np.datetime_as_string(dt, unit="h").replace("T", "-").split("-")
             )
-            dt_path = os.path.join(cache_path, f"{var}_{yy}{mm}{dd}{hh}.npz")
+            dt_path = os.path.join(cache_path, f"{var}_{yy}{mm}{dd}_{hh}.npz")
             print(f"Processing {dt_path}")
 
             try:
@@ -127,11 +288,15 @@ for fname in ["HighRes", "LowRes"]:
                 dt_data, lon_grid, lat_grid = u1.interp_to_domain(
                     lon_grid, lat_grid, dt_data, domain_size, method="linear"
                 )  # (1, Ny, Nx)
-
+                processed_files += 1
             except FileNotFoundError:
                 # create dummy data
                 dt_data = dummy_data.copy()
-                missing_data.append(f"{yy}-{mm}-{dd} {hh}:00")
+                missing_file = f"{yy}-{mm}-{dd} {hh}:00"
+                missing_data.append(missing_file)
+                missing_files += 1
+                logger.warning(f"Missing file, using dummy data: {os.path.basename(dt_path)}")
+
 
             # concatenate data
             if channel_arr is None:  # first iteration only
@@ -150,15 +315,17 @@ for fname in ["HighRes", "LowRes"]:
             # concatenate along axis=0 (time)
             data_arr = np.concatenate((data_arr, channel_arr), axis=0)
 
+    logger.info(f"File processing summary:")
+    logger.info(f"  - Successfully processed: {processed_files}")
+    logger.info(f"  - Missing files (dummy data used): {missing_files}")
+    logger.info(f"  - Total files expected: {total_hours * len(channel_vars_dict[fname])}")
+
     # compute mean and std over time, latitude & longitude → leaves (n_chan,)
     # data_arr shape is (n_time, n_chan, ny, nx)
-
     if data_arr.ndim == 4:
-        # mean/std over time, y, x → result per level
         means = np.nanmean(data_arr, axis=(0, 2, 3)).astype(np.float32)
         stds = np.nanstd(data_arr, axis=(0, 2, 3)).astype(np.float32)
     elif data_arr.ndim == 3:
-        # mean/std over all values → wrap in length-1 array
         m = np.nanmean(data_arr).astype(np.float32)
         s = np.nanstd(data_arr).astype(np.float32)
         means = np.array([m], dtype=np.float32)
@@ -166,96 +333,140 @@ for fname in ["HighRes", "LowRes"]:
     else:
         raise ValueError(f"Expected 3D or 4D array, got {data_arr.ndim}D.")
 
-    # ensure float32 precision
     means = means.astype(np.float32)
     stds = stds.astype(np.float32)
-    print(f"Check: {means}, {stds}")
+    
+    # Only save stats for training 
+    if not is_validation:
+        np.save(f"{folder_path}/means.npy", means)
+        np.save(f"{folder_path}/stds.npy", stds)
 
-    # save them
-    np.save(f"{folder_path}/means.npy", means)
-    np.save(f"{folder_path}/stds.npy", stds)
-
-    data_shape = (total_hours, num_channel) + domain_size
-    print(data_arr.shape)
+    print(f"Data shape: {data_arr.shape}")
+    
+    # Create xarray dataset
     year_data = xr.Dataset(
         {
             f"{fname}": (["time", "channel", "y", "x"], data_arr),
             "time": datetime_array,
-            "channel": channel_vars[fname],
+            "channel": channel_vars_dict[fname],
             "latitude": (["y", "x"], lat_grid),
             "longitude": (["y", "x"], lon_grid),
         }
     )
     data_enc = {f"{fname}": {"dtype": "float32", "compressor": None}}
+    out_name = "valid.zarr" if is_validation else "train.zarr"
     year_data.to_zarr(
-        f"{data_base}/{fname}/{experiment_name}.zarr",
+        f"{data_base}/{fname}/{out_name}",
         mode="w",
         consolidated=True,
         encoding=data_enc,
         zarr_format=2,
     )
-    zarr.consolidate_metadata(f"{data_base}/{fname}/{experiment_name}.zarr")
+    zarr.consolidate_metadata(f"{data_base}/{fname}/{out_name}")
 
     print(
-        f"Data for {experiment_name} saved to {data_base}/{fname}/{experiment_name}.zarr"
+        f"{'Validation' if is_validation else 'Data'} for {experiment_name} saved to {data_base}/{fname}/{out_name}"
+    )
+    logger.info(f"{period_type} data processing completed successfully")
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Create dataset zarrs and stats.")
+    parser.add_argument(
+        "--highres-vars",
+        choices=channel_vars["HighRes"],
+        default="t2m",
+        help="HighRes channel variables (comma-separated). Default: t2m",
+    )
+    parser.add_argument(
+        "--lowres-vars",
+        choices=channel_vars["LowRes"],
+        default="t2m",
+        help="LowRes channel variables (comma-separated). Default: t2m",
+    )
+    parser.add_argument(
+        "--train-start",
+        default=train_datetime_start,
+        help=f"Training start date YYYY/MM/DD (default {train_datetime_start})",
+    )
+    parser.add_argument(
+        "--train-end",
+        default=train_datetime_last,
+        help=f"Training end date YYYY/MM/DD (default {train_datetime_last})",
+    )
+    parser.add_argument(
+        "--val-start",
+        default=valid_datetime_start,
+        help=f"Validation start date YYYY/MM/DD (default {valid_datetime_start})",
+    )
+    parser.add_argument(
+        "--val-end",
+        default=valid_datetime_last,
+        help=f"Validation end date YYYY/MM/DD (default {valid_datetime_last})",
+    )
+    parser.add_argument(
+        "--cache-base", default=cache_base, help=f"Cache base path (default {cache_base})"
+    )
+    parser.add_argument(
+        "--data-base", default=data_base, help=f"Data base path (default {data_base})"
+    )
+    parser.add_argument(
+        "--process-invariants", 
+        action="store_true",
+        help="Process invariant data (land-sea mask, orography)"
     )
 
-# process invariants
-# determine data path base
-cache_path = f"{cache_base}/rwrf/train"
+    args = parser.parse_args()
 
-base_date = np.datetime64(test_datetime_start.replace("/", "-") + "T00:00:00")
-end_date = np.datetime64(test_datetime_last.replace("/", "-")) + np.timedelta64(23, "h")
-total_hours = int((end_date - base_date) / np.timedelta64(1, "h")) + 1
-offsets = np.arange(total_hours, dtype=np.int64)
-datetime_array = base_date + offsets * np.timedelta64(1, "h")
-dt = datetime_array[0]
-print(cache_path)
-invariant_arr = None
-for var in invariants:
-    yy, mm, dd, hh = np.datetime_as_string(dt, unit="h").replace("T", "-").split("-")
-    dt_path = os.path.join(cache_path, f"{var}_{yy}{mm}{dd}{hh}.npz")
-    print(f"Processing {dt_path}")
-
-    try:
-        dt_data, lon_grid, lat_grid, times = u1.extract_region(
-            dt_path,
-            var,
-            lon_min,
-            lon_max,
-            lat_min,
-            lat_max,
-            domain_size=domain_size,
-        )  # (1, Ny, Nx)
-        dt_data, lon_grid, lat_grid = u1.interp_to_domain(
-            lon_grid, lat_grid, dt_data, domain_size, method="linear"
-        )  # (1, Ny, Nx)
-
-    except FileNotFoundError:
-        raise FileNotFoundError(f"Invariant file not found: {dt_path}")
-
-    # concatenate data
-    if invariant_arr is None:  # first iteration only
-        invariant_arr = dt_data.copy()
-    else:
-        # concatenate along axis=0 (channel)
-        invariant_arr = np.concatenate((invariant_arr, dt_data), axis=0)
-
-year_data = xr.Dataset(
-    {
-        "HighRes_invariants": (["channel", "y", "x"], invariant_arr),
-        "channel": invariants,
-        "latitude": (["y", "x"], lat_grid),
-        "longitude": (["y", "x"], lon_grid),
+    # Parse channel variables
+    highres_vars = [v.strip() for v in args.highres_vars.split(",") if v.strip()]
+    lowres_vars = [v.strip() for v in args.lowres_vars.split(",") if v.strip()]
+    
+    channel_vars_dict = {
+        "HighRes": highres_vars,
+        "LowRes": lowres_vars,
+        "dummy": highres_vars[0] if highres_vars else "t2m"
     }
-)
-data_enc = {"HighRes_invariants": {"dtype": "float32", "compressor": None}}
-year_data.to_zarr(
-    f"{data_base}/invariants/invariants.zarr",
-    mode="w",
-    consolidated=True,
-    encoding=data_enc,
-    zarr_format=2,
-)
 
-print(f"Data for {experiment_name} saved to {data_base}/invariants/invariants.zarr")
+    # Process invariants if requested
+    if args.process_invariants:
+        process_invariants(
+            cache_base=args.cache_base,
+            data_base=args.data_base,
+            experiment_name=experiment_name,
+            start_date=args.train_start,
+        )
+
+    # process training period
+    for fname in ["HighRes", "LowRes"]:
+        process_period(
+            start_date=args.train_start,
+            end_date=args.train_end,
+            fname=fname,
+            channel_vars_dict=channel_vars_dict,
+            cache_base=args.cache_base,
+            data_base=args.data_base,
+            domain_size=domain_size,
+            experiment_name=experiment_name,
+            is_validation=False,
+        )
+
+    # process validation period
+    for fname in ["HighRes", "LowRes"]:
+        process_period(
+            start_date=args.val_start,
+            end_date=args.val_end,
+            fname=fname,
+            channel_vars_dict=channel_vars_dict,
+            cache_base=args.cache_base,
+            data_base=args.data_base,
+            domain_size=domain_size,
+            experiment_name=experiment_name,
+            is_validation=True,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/rwrf_process/fetch_era5.py
+++ b/dev/rwrf_process/fetch_era5.py
@@ -1,68 +1,155 @@
-import argparse
-import os
-from datetime import datetime
-
-import numpy as np
-from netCDF4 import Dataset
 from utils.config import CONFIG
+from netCDF4 import Dataset
+from datetime import datetime, timedelta
+import os
+import numpy as np
+import argparse
+import logging
+from typing import Dict, Tuple, Optional
+from dataclasses import dataclass
+from pathlib import Path
 
-var_map = {
-    "t2m": "t2m",
-    "u10": "u10",
-    "pptn": "tp",
-    # add any others here...
-}
-
-
-def load_era5_interp_nc(date_str: str, hr_str: str, variable: str) -> Dataset:
-    dt = datetime.strptime(date_str, "%Y/%m/%d")
-    folder = CONFIG.era5
-    if variable == "pptn":
-        filepath = dt.strftime(f"{folder}/tp_%Y%m%d") + hr_str.zfill(2) + ".nc"
-    else:
-        filepath = dt.strftime(f"{folder}/{variable}_%Y%m%d") + hr_str.zfill(2) + ".nc"
-    if not os.path.exists(filepath):
-        # raise FileNotFoundError(f"File not found: {filepath}") # use this after all files are downloaded
-        print(f"WARNING: File not found: {filepath}, skipping...")  # use this for now
-    ds = Dataset(filepath, mode="r")
-
-    return ds
+# Setup logger
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
 
 
-def save_t2m_numpy(
-    date_str: str,
-    hr_str: str,
-    variable: str,
-    out_dir: str = "../data/cache/era5/train/",
-):
-    # 1) load dataset
-    ds = load_era5_interp_nc(date_str, hr_str, variable)
+@dataclass
+class VariableConfig:
+    """Configuration for different ERA5 variables"""
+    nc_var_name: str
+    file_prefix: str
 
-    # 2) grab the raw arrays
-    for key in ["latitude", "longitude", "valid_time", var_map.get(variable, variable)]:
-        if key not in ds.variables:
-            raise KeyError(
-                f"Key '{key}' not found in dataset variables: {list(ds.variables.keys())}"
+
+class ERA5Processor:
+    """Handles ERA5 data processing and conversion to numpy arrays"""
+    
+    VARIABLE_CONFIGS = {
+        # t1000  t2m  t925  u10  u1000  u200  u250  u500  u700  u850  u925  v10  v1000  v200  v250  v500  v700  v850  v925
+        "t2m": VariableConfig("t2m", "t2m"),
+        "u10": VariableConfig("u10", "u10"),
+        "pptn": VariableConfig("tp", "tp"),
+        "t1000": VariableConfig("t", "t1000"),
+        "t925": VariableConfig("t", "t925"),
+        "u1000": VariableConfig("u", "u1000"),
+        "u200": VariableConfig("u", "u200"),
+        "u250": VariableConfig("u", "u250"),
+        "u500": VariableConfig("u", "u500"),
+        "u700": VariableConfig("u", "u700"),
+        "u850": VariableConfig("u", "u850"),
+        "u925": VariableConfig("u", "u925"),
+        "v10": VariableConfig("v10", "v10"),
+        "v1000": VariableConfig("v", "v1000"),
+        "v200": VariableConfig("v", "v200"),
+        "v250": VariableConfig("v", "v250"),
+        "v500": VariableConfig("v", "v500"),
+        "v700": VariableConfig("v", "v700"),
+        "v850": VariableConfig("v", "v850"),
+        "v925": VariableConfig("v", "v925"),
+    }
+    
+    def __init__(self, era5_base_path: str, output_base_path: str):
+        self.era5_base_path = Path(era5_base_path)
+        self.output_base_path = Path(output_base_path)
+        self.output_base_path.mkdir(parents=True, exist_ok=True) 
+    
+    def _get_file_path(self, date: datetime, hour: int, variable: str) -> Path:
+        """Generate the file path for a given date, hour, and variable"""
+        config = self.VARIABLE_CONFIGS[variable]
+        hour_str = f"{hour:02d}"
+        date_str = date.strftime('%Y%m%d')
+        
+        return self.era5_base_path / variable / date.strftime('%Y') / f"{config.file_prefix}_{date_str}{hour_str}.nc"
+
+    
+    def _load_dataset(self, date: datetime, hour: int, variable: str) -> Optional[Dataset]:
+        """Load ERA5 dataset for given parameters"""
+        filepath = self._get_file_path(date, hour, variable)
+        
+        if not filepath.exists():
+            raise FileNotFoundError(f"NC file not found: {filepath}")
+        
+        return Dataset(str(filepath), mode="r")
+    
+    def _extract_data(self, ds: Dataset, variable: str) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Extract data arrays from dataset"""
+        config = self.VARIABLE_CONFIGS[variable]
+        
+        # Common coordinates
+        lat = ds.variables["latitude"][:]
+        lon = ds.variables["longitude"][:]
+        times = ds.variables["valid_time"][:]
+        
+        # Variable-specific data
+        data = ds.variables[config.nc_var_name][:]
+        
+        return data, lat, lon, times
+    
+    def process_single_time(self, date: datetime, hour: int, variable: str) -> bool:
+        """Process a single time step and save as numpy array"""
+        try:
+            ds = self._load_dataset(date, hour, variable)
+        except FileNotFoundError as e:
+            logger.warning("%s — skipping %s %02d:00", e, date.strftime('%Y/%m/%d'), hour)
+            return False
+        
+        try:
+            logger.debug("Variables in dataset: %s", list(ds.variables.keys()))
+            
+            # Extract data
+            data, lat, lon, times = self._extract_data(ds, variable)
+            
+            # Ensure output directory exists
+            output_dir = self.output_base_path 
+            output_dir.mkdir(parents=True, exist_ok=True)
+            
+            # Save as .npz
+            filename = f"{variable}_{date.strftime('%Y%m%d')}_{hour:02d}.npz"
+            output_path = output_dir / filename
+            
+            np.savez(
+                str(output_path),
+                **{variable: data},
+                lat=lat,
+                lon=lon,
+                times=times
             )
-
-    lat = ds.variables["latitude"][:]  # (721, )
-    lon = ds.variables["longitude"][:]  # (1440, )
-    times = ds.variables["valid_time"][:]  # unix format (1,)
-    data = ds.variables[var_map.get(variable, variable)][
-        :
-    ]  # often shape (1, 721, 1440)
-
-    ds.close()
-    # 3) ensure output dir
-    os.makedirs(out_dir, exist_ok=True)
-
-    # 4) save as .npz (multiple arrays in one file)
-    if variable == "pptn":
-        variable = "qpepre"
-    fn = f"{variable}_" + date_str.replace("/", "") + f"{hr_str}.npz"
-    out_path = os.path.join(out_dir, fn)
-    np.savez(out_path, **{variable: data}, lat=lat, lon=lon, times=times)
-    print(f"Saved arrays to {out_path}")
+            
+            logger.info("Saved arrays to %s", output_path)
+            return True
+            
+        except Exception as e:
+            logger.error("Error processing %s %02d:00: %s", date.strftime('%Y/%m/%d'), hour, e)
+            return False
+        finally:
+            ds.close()
+    
+    def process_date_range(self, start_date: datetime, end_date: datetime, 
+                          variable: str, hour_step: int = 1) -> Dict[str, int]:
+        """Process a range of dates"""
+        stats = {"processed": 0, "skipped": 0, "errors": 0}
+        
+        current = start_date
+        while current <= end_date:
+            for hour in range(0, 24, hour_step):
+                logger.info("Processing %s %02d:00", current.strftime('%Y/%m/%d'), hour)
+                
+                try:
+                    if self.process_single_time(current, hour, variable):
+                        stats["processed"] += 1
+                    else:
+                        stats["skipped"] += 1
+                except Exception:
+                    logger.exception("Unexpected error for %s %02d:00", 
+                                   current.strftime('%Y/%m/%d'), hour)
+                    stats["errors"] += 1
+            
+            current += timedelta(days=1)
+        
+        return stats
 
 
 def main():
@@ -71,18 +158,63 @@ def main():
     )
     parser.add_argument(
         "--variable",
-        choices=[var for var in var_map.keys()],
         required=True,
-        help="Variable to extract:",
+        # t1000  t2m  t925  u10  u1000  u200  u250  u500  u700  u850  u925  v10  v1000  v200  v250  v500  v700  v850  v925
+        choices=["t2m", "u10", "pptn", "t1000", "t925", "u1000", "u200", "u250", "u500", "u700", "u850", "u925", "v10", "v1000", "v200", "v250", "v500", "v700", "v850", "v925"],
+        help="Variable to extract: t2m, u10, or pptn",
     )
+    parser.add_argument(
+        "--start-date",
+        default="2019/08/03",
+        help="Start date (YYYY/MM/DD). Default: 2019/08/03",
+    )
+    parser.add_argument(
+        "--end-date",
+        default="2019/08/04",
+        help="End date (YYYY/MM/DD). Default: 2019/08/04",
+    )
+    parser.add_argument(
+        "--hour-step",
+        type=int,
+        default=6,
+        help="Hour step between outputs (default 1). Use 6 for every 6 hours.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    parser.add_argument(
+        "--output-dir", default=str(CONFIG.era5_npz),
+        help="Output base directory for .npz files (will be created if missing)")
+    
     args = parser.parse_args()
-    for date_str in CONFIG.date_strs:
-        for hr_str in CONFIG.hr_strs:
-            print(
-                f"Transforming ERA5 {date_str.replace('/', '')}{hr_str}.nc {args.variable} to numpy array..."
-            )
-            save_t2m_numpy(date_str, hr_str, args.variable)
+    
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+    
+    # Parse dates
+    try:
+        start_date = datetime.strptime(args.start_date, "%Y/%m/%d")
+        end_date = datetime.strptime(args.end_date, "%Y/%m/%d")
+    except ValueError as e:
+        logger.error("Invalid date format: %s", e)
+        return 1
+    
+    # Initialize processor
+    processor = ERA5Processor(CONFIG.era5, args.output_dir)
+    
+    # Process data
+    logger.info("Starting processing: %s from %s to %s (step: %dh)", 
+                args.variable, args.start_date, args.end_date, args.hour_step)
+    
+    stats = processor.process_date_range(start_date, end_date, args.variable, args.hour_step)
+    
+    logger.info("Processing complete. Processed: %d, Skipped: %d, Errors: %d", 
+                stats["processed"], stats["skipped"], stats["errors"])
+    
+    return 0 if stats["errors"] == 0 else 1
 
 
 if __name__ == "__main__":
-    main()
+    exit(main())

--- a/dev/rwrf_process/fetch_rwrf.py
+++ b/dev/rwrf_process/fetch_rwrf.py
@@ -1,98 +1,233 @@
-import argparse
-import os
-from datetime import datetime
-from typing import Optional
+#!/usr/bin/env python3
+# fetch_rwrf.py — refactored to match fetch_era5 style
 
-import numpy as np
-from netCDF4 import Dataset
 from utils.config import CONFIG
+from netCDF4 import Dataset
+from datetime import datetime, timedelta
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Tuple, Optional
+import numpy as np
+import argparse
+import logging
+import os
 
-var_map = {
-    "t2m": "T2",
-    "u10": "umet10",
-    "pptn": "qpepre",
-    "lsm": "LANDMASK",
-    "orog": "HGT",
-    # add any others here...
+# -------------------- logging --------------------
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# -------------------- variable config --------------------
+# Map CLI variable names -> (WRF variable key in file, saved name, filename flavor)
+# saved_name controls the variable key inside the .npz
+# For pptn we read 'qpepre' and also save as 'qpepre'
+@dataclass
+class VariableConfig:
+    wrf_var_key: str        # variable name in the NetCDF file
+    saved_name: str         # key stored in npz
+    fn_flavor: str = "std"  # 'std' or 'pptn_qpepre' (affects filepath rule)
+
+VARIABLES: Dict[str, VariableConfig] = {
+    # t2m/u10/etc. come from wrf interp file without suffix
+    "t2m":   VariableConfig("T2",      "t2m",   "std"),
+    "u10":   VariableConfig("umet10",  "u10",   "std"),
+    "lsm":   VariableConfig("LANDMASK","lsm",   "std"),
+    "orog":  VariableConfig("HGT",     "orog",  "std"),
+    # precip (pptn) lives in a different filename; inside file var is 'qpepre'
+    "pptn":  VariableConfig("qpepre",  "qpepre","pptn_qpepre"),
 }
 
+# -------------------- processor --------------------
+class RWRFProcessor:
+    """
+    Process RWRF (interpolated) outputs into .npz bundles:
+    np.savez(..., <saved_name>=data, lat=XLAT, lon=XLONG, times=Times)
+    """
+    def __init__(self, rwrf_base_path: str, output_base_path: str, cropped_qpepre: bool = False):
+        self.rwrf_base = Path(rwrf_base_path)
+        self.out_base = Path(output_base_path)
+        self.out_base.mkdir(parents=True, exist_ok=True)
+        self.cropped_qpepre = cropped_qpepre
 
-def load_wrf_interp_nc(
-    date_str: str,
-    hr_str: str,
-    variable: Optional[str] = None,
-    cropped_qpepre: bool = False,
-) -> Dataset:
-    dt = datetime.strptime(date_str, "%Y/%m/%d")
-    fmt_dt_str = dt.strftime(f"%Y-%m-%d_{int(hr_str):02d}")
-    folder = CONFIG.rwrf
-    if variable == "pptn":
-        if cropped_qpepre:
-            filepath = f"{folder}/{fmt_dt_str}/wrfout_d01_{fmt_dt_str}_interp_cropped_qpepre.nc"
+    @staticmethod
+    def _format_dt(date: datetime, hour: int) -> str:
+        # YYYY-MM-DD_HH
+        return date.strftime(f"%Y-%m-%d_{hour:02d}")
+
+    def _build_filepath(self, date: datetime, hour: int, varkey: str) -> Path:
+        """
+        Build the RWRF netCDF path based on variable name and date/hour.
+        Folder layout:
+          <CONFIG.rwrf>/RWRF_YYYY-MM/YYYY-MM-DD_HH/<file>
+        Files:
+          std:        wrfout_d01_YYYY-MM-DD_HH_interp
+          pptn_qpepre: wrfout_d01_YYYY-MM-DD_HH_interp_qpepre.nc
+                       or wrfout_d01_YYYY-MM-DD_HH_interp_cropped_qpepre.nc (if cropped flag)
+        """
+        cfg = VARIABLES[varkey]
+        month_folder = f"RWRF_{date.strftime('%Y-%m')}"
+        stamp = self._format_dt(date, hour)
+        base_dir = self.rwrf_base / month_folder / stamp
+
+        if cfg.fn_flavor == "pptn_qpepre":
+            if self.cropped_qpepre:
+                fname = f"wrfout_d01_{stamp}_interp_cropped_qpepre.nc"
+            else:
+                fname = f"wrfout_d01_{stamp}_interp_qpepre.nc"
         else:
-            filepath = f"{folder}/{fmt_dt_str}/wrfout_d01_{fmt_dt_str}_interp_qpepre.nc"
-    else:
-        filepath = f"{folder}/{fmt_dt_str}/wrfout_d01_{fmt_dt_str}_interp"
-    if not os.path.exists(filepath):
-        # raise FileNotFoundError(f"File not found: {filepath}") # use this after all files are downloaded
-        print(f"WARNING: File not found: {filepath}, skipping...")  # use this for now
-    ds = Dataset(filepath, mode="r")
-    return ds
+            # Some environments store this file without .nc extension; handle both.
+            # Prefer with extension if exists, else fallback to no-extension.
+            with_ext = base_dir / f"wrfout_d01_{stamp}_interp.nc"
+            no_ext   = base_dir / f"wrfout_d01_{stamp}_interp"
+            if with_ext.exists():
+                return with_ext
+            return no_ext
 
+        return base_dir / fname
 
-def save_t2m_numpy(
-    date_str: str,
-    hr_str: str,
-    variable: str,
-    cropped_qpepre: bool = False,
-    out_dir: str = "../data/cache/rwrf/train/",
-):
-    # 1) load dataset
-    ds = load_wrf_interp_nc(date_str, hr_str, variable, cropped_qpepre)
+    def _open_dataset(self, date: datetime, hour: int, varkey: str) -> Dataset:
+        path = self._build_filepath(date, hour, varkey)
+        if not path.exists():
+            raise FileNotFoundError(f"NC file not found: {path}")
+        return Dataset(str(path), mode="r")
 
-    # 2) grab the raw arrays
-    data = ds.variables[var_map.get(variable, variable)][:]
-    lat = ds.variables["XLAT"][:]  # often shape (time, y, x)
-    lon = ds.variables["XLONG"][:]
-    times = ds.variables["Times"][:]  # WRF Times: char array
+    def _extract_arrays(self, ds: Dataset, varkey: str) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        cfg = VARIABLES[varkey]
+        try:
+            data = ds.variables[cfg.wrf_var_key][:]
+        except KeyError:
+            # Helpful error with available keys
+            raise KeyError(f"Variable '{cfg.wrf_var_key}' not found in file; available={list(ds.variables.keys())}")
 
-    ds.close()
+        # Coordinates / time in WRF outputs
+        try:
+            lat   = ds.variables["XLAT"][:]   # (time, y, x)
+            lon   = ds.variables["XLONG"][:]
+        except KeyError:
+            # Sometimes lowercase or different naming—add fallbacks if your files differ
+            raise KeyError(f"Missing XLAT/XLONG in file; available={list(ds.variables.keys())}")
 
-    # 3) ensure output dir
-    os.makedirs(out_dir, exist_ok=True)
+        # WRF Times: char array, keep raw as-is
+        tkey = "Times" if "Times" in ds.variables else None
+        if tkey is None:
+            raise KeyError(f"Missing 'Times' variable; available={list(ds.variables.keys())}")
+        times = ds.variables[tkey][:]
 
-    # 4) save as .npz (multiple arrays in one file)
-    if variable == "pptn":
-        variable = "qpepre"
-    fn = f"{variable}_" + date_str.replace("/", "") + f"{hr_str}.npz"
-    out_path = os.path.join(out_dir, fn)
-    np.savez(out_path, **{variable: data}, lat=lat, lon=lon, times=times)
-    print(f"Saved arrays to {out_path}")
+        return data, lat, lon, times
 
+    def process_single_time(self, date: datetime, hour: int, varkey: str) -> bool:
+        try:
+            ds = self._open_dataset(date, hour, varkey)
+        except FileNotFoundError as e:
+            logger.warning("%s — skipping %s %02d:00", e, date.strftime("%Y/%m/%d"), hour)
+            return False
 
+        try:
+            data, lat, lon, times = self._extract_arrays(ds, varkey)
+
+            # Output path: <out_base>/<variable>/<year>/<name>.npz
+            year_dir = self.out_base 
+            year_dir.mkdir(parents=True, exist_ok=True)
+
+            saved_name = VARIABLES[varkey].saved_name
+            fname = f"{saved_name}_{date.strftime('%Y%m%d')}_{hour:02d}.npz"
+            out_path = year_dir / fname
+
+            np.savez(str(out_path), **{saved_name: data}, lat=lat, lon=lon, times=times)
+            logger.info("Saved arrays to %s", out_path)
+            return True
+
+        except KeyError as e:
+            logger.error("Key error at %s %02d:00 -> %s", date.strftime("%Y/%m/%d"), hour, e)
+            return False
+        except Exception as e:
+            logger.exception("Error processing %s %02d:00: %s", date.strftime("%Y/%m/%d"), hour, e)
+            return False
+        finally:
+            ds.close()
+
+    def process_date_range(
+        self,
+        start_date: datetime,
+        end_date: datetime,
+        varkey: str,
+        hour_step: int = 6
+    ) -> Dict[str, int]:
+        stats = {"processed": 0, "skipped": 0, "errors": 0}
+        cur = start_date
+        while cur <= end_date:
+            for hour in range(0, 24, hour_step):
+                logger.info("Processing %s %02d:00", cur.strftime("%Y/%m/%d"), hour)
+                ok = self.process_single_time(cur, hour, varkey)
+                if ok:
+                    stats["processed"] += 1
+                else:
+                    # Distinguish between file-not-found/KeyError and hard exceptions already logged
+                    # Here we just count as skipped; 'errors' are counted inside process_single_time when exceptions occur.
+                    stats["skipped"] += 1
+            cur += timedelta(days=1)
+        return stats
+
+# -------------------- CLI --------------------
 def main():
-    parser = argparse.ArgumentParser(
-        description="Extract RWRF data and save as numpy arrays."
-    )
+    parser = argparse.ArgumentParser(description="Extract RWRF data and save as numpy arrays (refactor).")
     parser.add_argument(
         "--variable",
-        choices=[var for var in var_map.keys()],
         required=True,
-        help="Variable to extract:",
+        choices=list(VARIABLES.keys()),
+        help="Variable to extract (e.g., t2m, u10, pptn, lsm, orog)",
     )
     parser.add_argument(
         "--cropped-qpepre",
         action="store_true",
-        help="Use cropped RWRF data by QPEPRE",
+        help="Use cropped QPEPRE file for pptn (wrfout_*_interp_cropped_qpepre.nc)",
     )
+    parser.add_argument("--start-date", default="2019/08/03", help="Start date YYYY/MM/DD")
+    parser.add_argument("--end-date",   default="2019/08/04", help="End date YYYY/MM/DD")
+    parser.add_argument("--hour-step",  type=int, default=6,  help="Hour step (default 6). Use 1 to process every hour.")
+    parser.add_argument("--output-dir", default=str(CONFIG.rwrf_npz), help="Output base directory for .npz files")
+    parser.add_argument("--verbose",    action="store_true", help="Enable debug logging")
     args = parser.parse_args()
-    for date_str in CONFIG.date_strs:
-        for hr_str in CONFIG.hr_strs:
-            print(
-                f"Transforming RWRF {date_str.replace('/', '')}{hr_str}.nc {args.variable} to numpy array..."
-            )
-            save_t2m_numpy(date_str, hr_str, args.variable)
+
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+
+    # Parse dates
+    try:
+        start = datetime.strptime(args.start_date, "%Y/%m/%d")
+        end   = datetime.strptime(args.end_date,   "%Y/%m/%d")
+    except ValueError as e:
+        logger.error("Invalid date format: %s", e)
+        return 1
+
+    # Build processor
+    if args.variable != "pptn" and args.cropped_qpepre:
+        logger.warning("--cropped-qpepre has no effect for variable '%s'", args.variable)
+
+    processor = RWRFProcessor(
+        rwrf_base_path=CONFIG.rwrf,
+        output_base_path=args.output_dir,
+        cropped_qpepre=args.cropped_qpepre
+    )
+
+    logger.info(
+        "Starting RWRF processing: var=%s, %s → %s, step=%dh, output=%s",
+        args.variable, args.start_date, args.end_date, args.hour_step, args.output_dir
+    )
+
+    stats = processor.process_date_range(start, end, args.variable, args.hour_step)
+
+    logger.info(
+        "Processing complete. Processed: %d, Skipped: %d, Errors: %d",
+        stats["processed"], stats["skipped"], stats["errors"]
+    )
+
+    # Return non-zero if any errors were logged as exceptions (we count those inside process_single_time).
+    # Here we treat 'skipped' as non-fatal (missing files, etc.).
+    return 0 if stats["errors"] == 0 else 1
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/dev/rwrf_process/utils/config.py
+++ b/dev/rwrf_process/utils/config.py
@@ -6,6 +6,8 @@ class Config:
         self.dataset_paths = config_dict["dataset_paths"]
         self.rwrf = self.dataset_paths["rwrf"]
         self.era5 = self.dataset_paths["era5"]
+        self.era5_npz = self.dataset_paths["era5_npz"]
+        self.rwrf_npz = self.dataset_paths["rwrf_npz"]
         self.qpepre = self.dataset_paths["qpepre"]
         self.date_strs = config_dict["date_strs"]
         self.hr_strs = config_dict["hr_strs"]

--- a/examples/weather/stormcast/config/dataset/small.yaml
+++ b/examples/weather/stormcast/config/dataset/small.yaml
@@ -24,9 +24,9 @@ HighRes_img_size: [32, 32]
 
 # Temporal selection
 dt: 1 # Timestep between samples (in multiples of the base HRRR 1hr timestep)
-exp_train_zarrs: ["exp"] # Zarr files to use for training
+exp_train_zarrs: ["train"] # Zarr files to use for training
 train_dates: ['2019/08/03', '2019/08/03']
-exp_valid_zarrs: ["exp"] # Zarr files to use for validation
+exp_valid_zarrs: ["valid"] # Zarr files to use for validation
 valid_dates: ['2019/08/03', '2019/08/03']
 
 # Variable selection

--- a/examples/weather/stormcast/datasets/data_loader_small.py
+++ b/examples/weather/stormcast/datasets/data_loader_small.py
@@ -133,7 +133,7 @@ class Dataset(StormCastDataset):
         self.logger0.info(f"list of all LowRes paths: {self.LowRes_paths}")
 
         if self.train:
-            # keep only zarr files specified in the params.exp_train_zarrs list
+            # keep only zarr files specified in the params.train list
             self.LowRes_paths = [
                 x
                 for x in self.LowRes_paths
@@ -144,7 +144,7 @@ class Dataset(StormCastDataset):
                 os.path.basename(x).replace(".zarr", "") for x in self.LowRes_paths
             ]
         else:
-            # keep only zarr files specified in the params.exp_valid_zarrs list
+            # keep only zarr files specified in the params.valid_dates list
             self.LowRes_paths = [
                 x
                 for x in self.LowRes_paths
@@ -179,7 +179,7 @@ class Dataset(StormCastDataset):
             self.HighRes_paths, key=lambda p: os.path.basename(p).replace(".zarr", "")
         )
         if self.train:
-            # keep only zarr files specified in the params.exp_train_zarrs list
+            # keep only zarr files specified in the params.train_dates list
             self.HighRes_paths = [
                 x
                 for x in self.HighRes_paths
@@ -237,8 +237,13 @@ class Dataset(StormCastDataset):
         """
         Loop through all years and count the total number of samples
         """
-        test_datetime_start = self.params.train_dates[0]
-        test_datetime_last = self.params.train_dates[1]
+        # Use different date ranges for train vs validation
+        if self.train:
+            test_datetime_start = self.params.train_dates[0]
+            test_datetime_last = self.params.train_dates[1]
+        else:
+            test_datetime_start = self.params.valid_dates[0]
+            test_datetime_last = self.params.valid_dates[1]
 
         first_sample = datetime.strptime(
             test_datetime_start, "%Y/%m/%d") \

--- a/examples/weather/stormcast/utils/trainer.py
+++ b/examples/weather/stormcast/utils/trainer.py
@@ -45,6 +45,21 @@ from torch.nn.utils import clip_grad_norm_
 
 logger = PythonLogger("train")
 
+def print_dataset_info(dataset, name="dataset"):
+    logger0 = dataset.logger0 if hasattr(dataset, "logger0") else print
+    logger0.info(f"--- {name} info ---")
+    logger0.info(f"date_ranges: {dataset.date_ranges}")
+    logger0.info(f"LowRes_zarrs: {getattr(dataset, 'LowRes_zarrs', None)}")
+    logger0.info(f"HighRes_zarrs: {getattr(dataset, 'HighRes_zarrs', None)}")
+    logger0.info(f"LowRes_channels: {getattr(dataset, 'LowRes_channels', None)}")
+    logger0.info(f"HighRes_channels: {getattr(dataset, 'HighRes_channels', None)}")
+    logger0.info(f"n_samples_total: {getattr(dataset, 'n_samples_total', None)}")
+    logger0.info(f"valid_samples (first 5): {getattr(dataset, 'valid_samples', None)[:5]}")
+    logger0.info(f"image_shape: {dataset.image_shape()}")
+    logger0.info(f"background_channels: {dataset.background_channels()}")
+    logger0.info(f"state_channels: {dataset.state_channels()}")
+    logger0.info(f"invariants: {dataset.get_invariants()}")
+    logger0.info(f"-------------------")
 
 def training_loop(cfg):
 
@@ -53,7 +68,7 @@ def training_loop(cfg):
     dist = DistributedManager()
     device = dist.device
     logger0 = RankZeroLoggingWrapper(logger, dist)
-
+   
     # Shorthand for config items
     batch_size = cfg.training.batch_size
     if cfg.training.batch_size_per_gpu == "auto":
@@ -95,10 +110,19 @@ def training_loop(cfg):
     logger0.info("Loading dataset...")
 
     dataset_cls = dataset_classes[cfg.dataset.name]
+    logger0.info(f"Dataset class: {dataset_cls.__name__}")
+    # log dataset type
+    logger0.info(f"Dataset type: {cfg.dataset.name}")
     del cfg.dataset.name
 
+    #log preparing dataset train 
+    logger0.info("Preparing dataset train splits...")
     dataset_train = dataset_cls(cfg.dataset, train=True)
+    logger0.info("Preparing dataset valid splits...")
     dataset_valid = dataset_cls(cfg.dataset, train=False)
+    
+    print_dataset_info(dataset_train, "Train")
+    print_dataset_info(dataset_valid, "Valid")
 
     background_channels = dataset_train.background_channels()
     state_channels = dataset_train.state_channels()
@@ -300,6 +324,7 @@ def training_loop(cfg):
 
         # Perform validation step
         if total_steps % cfg.training.validation_freq == 0:
+            logger0.info(f"Validating at step {total_steps}...")
             valid_start = time.time()
             batch = next(valid_dataset_iterator)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
- Introduces separate train.zarr and valid.zarr outputs (instead of a shared file).
- Adds configuration for pointing to the validation dataset path.
- Improves output directory structure for NPZ processing (e.g., processed npz paths).
- Enables validation support in StormCast’s RWRF training workflow.
- Adds configurable arguments for `fetch_era5.py`, `fetch_rwrf.py` and `create_data.py`

basic command example for `fetch_era5.py` :
```python
python fetch_era5.py \
  --variable t2m \
  --start-date 2019/01/01 \
  --end-date 2019/01/02 \
  --hour-step 6 \
  --output-dir cache/era5
```

basic command example for `fetch_rwrf.py` :
```python
python fetch_rwrf.py \
  --variable t2m \
  --start-date 2019/01/01 \
  --end-date 2019/01/02 \
  --hour-step 6 \
  --output-dir cache/era5
```

basic command example for `create_data.py` :
```python
python create_data.py \
  --highres-vars t2m,u10,qpepre \
  --lowres-vars t2m,u10,pptn \
  --train-start 2019/08/01 \
  --train-end   2019/08/31 \
  --val-start   2019/09/01 \
  --val-end     2019/09/07 \
  --cache-base  /workspace/physicsnemo/dev/rwrf_process/cache \
  --data-base   ../data \
  --process-invariants
```

## Result of taking data of 2019/08/03 as training dataset and data of 2019/08/04 as validation dataset
### validation at step 50 
<img width="499" height="332" alt="image" src="https://github.com/user-attachments/assets/ef25d796-3146-4293-aabc-744c9848df2f" />
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/ba29d0d7-e4dc-49ad-b37b-b49c1978978a" />

### validation at step 100
<img width="600" height="400" alt="image" src="https://github.com/user-attachments/assets/9121faf0-30b4-4c09-90c0-829524554855" />
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/56bbdde2-0f56-45a3-9aa7-a4e63bbc9e2e" />

### validation at step 100
<img width="600" height="400" alt="image" src="https://github.com/user-attachments/assets/42084aa7-0dc5-44a5-a4e1-c31afc764def" />
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/19ec7681-e58f-4d60-af4c-9e57f432895c" />

it can be confirmed that model gradually converges instead of overfitting at the beginning.

## Related Issue
https://github.com/running-berry/physicsnemo/issues/55

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->