### PR TITLE
Parallelize RWRF→NPZ (QPEPRE merge) and add concurrent NPZ coverage checker; unify logging & imports

### DIFF
--- a/dev/rwrf_process/des_process_rwrf_qpe/check_rwrf_npz_missing.py
+++ b/dev/rwrf_process/des_process_rwrf_qpe/check_rwrf_npz_missing.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""
+check_rwrf_npz_missing.py
+
+Parallel scanner to report missing (and optionally unreadable) RWRF NPZ files
+for a date range and hour list.
+
+- Filename pattern: "{variable}_{YYYYMMDD}{HH}.npz"
+- Uses ProcessPoolExecutor for concurrency (configurable with --workers)
+"""
+
+import argparse
+import logging
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Iterable, List, Tuple, Dict, Optional
+from concurrent.futures import ProcessPoolExecutor, as_completed
+import multiprocessing
+
+logger = logging.getLogger("check_rwrf_npz")
+
+# ---------- Variables list (defaults) ----------
+DEFAULT_VARIABLES = [
+    "u10","v10","t2m","sp","msl","tcwv",
+    "u50","u100","u150","u200","u250","u300","u400","u500","u600","u700","u850","u925","u1000",
+    "v50","v100","v150","v200","v250","v300","v400","v500","v600","v700","v850","v925","v1000",
+    "z50","z100","z150","z200","z250","z300","z400","z500","z600","z700","z850","z925","z1000",
+    "t50","t100","t150","t200","t250","t300","t400","t500","t600","t700","t850","t925","t1000",
+    "q50","q100","q150","q200","q250","q300","q400","q500","q600","q700","q850","q925","q1000",
+    "qpepre","lsm","orog",
+]
+
+# ---------- CLI helpers ----------
+def parse_hours(hours: str) -> List[str]:
+    parts = [p.strip() for p in hours.split(",") if p.strip()]
+    out: List[str] = []
+    for p in parts:
+        if not p.isdigit():
+            raise ValueError(f"Invalid hour '{p}' (must be 0..23).")
+        v = int(p)
+        if not (0 <= v <= 23):
+            raise ValueError(f"Invalid hour '{p}' (must be 0..23).")
+        out.append(f"{v:02d}")
+    if not out:
+        raise ValueError("No hours parsed from --hours.")
+    return out
+
+def parse_variables(vars_str: Optional[str]) -> List[str]:
+    if not vars_str:
+        return DEFAULT_VARIABLES
+    parts = [p.strip() for p in vars_str.split(",") if p.strip()]
+    if not parts:
+        raise ValueError("No variables parsed from --variables.")
+    return parts
+
+def date_range_inclusive(start_ymd_slash: str, end_ymd_slash: str) -> List[str]:
+    fmt = "%Y/%m/%d"
+    start = datetime.strptime(start_ymd_slash, fmt).date()
+    end = datetime.strptime(end_ymd_slash, fmt).date()
+    if start > end:
+        start, end = end, start
+    days = (end - start).days + 1
+    return [(start + timedelta(days=i)).strftime("%Y%m%d") for i in range(days)]
+
+# ---------- Model ----------
+@dataclass(frozen=True)
+class ExpectedFile:
+    variable: str
+    yyyymmdd: str
+    hh: str
+    path: Path
+
+def expected_files(root: Path, variables: Iterable[str], yyyymmdds: Iterable[str], hours: Iterable[str]) -> List[ExpectedFile]:
+    return [ExpectedFile(v, d, h, root / f"{v}_{d}{h}.npz")
+            for v in variables for d in yyyymmdds for h in hours]
+
+# ---------- Worker ----------
+def _probe_file(args: Tuple[str, str, str, str, bool]) -> Tuple[str, str, str, str, str]:
+    """
+    Worker that checks a single file.
+
+    Returns tuple: (status, variable, yyyymmdd, hh, path)
+      status in {"ok", "missing", "unreadable"}
+    """
+    variable, yyyymmdd, hh, path_str, strict = args
+    p = Path(path_str)
+    logger.info("checking %s", p)
+    if not p.exists():
+        return ("missing", variable, yyyymmdd, hh, path_str)
+    if not strict:
+        return ("ok", variable, yyyymmdd, hh, path_str)
+    # Strict: try to open to ensure valid NPZ
+    try:
+        import numpy as np
+        with np.load(p, allow_pickle=False) as _:
+            pass
+        return ("ok", variable, yyyymmdd, hh, path_str)
+    except Exception:
+        return ("unreadable", variable, yyyymmdd, hh, path_str)
+
+# ---------- Parallel check ----------
+def check_files_mp(files: List[ExpectedFile], strict: bool, workers: int) -> Tuple[List[ExpectedFile], List[ExpectedFile]]:
+    logger.info("Checking %d expected files (strict=%s, workers=%d)...", len(files), strict, workers)
+
+    tasks = [(f.variable, f.yyyymmdd, f.hh, str(f.path), strict) for f in files]
+    missing: List[ExpectedFile] = []
+    unreadable: List[ExpectedFile] = []
+
+    # NOTE: per-file DEBUG logging only (INFO would be too noisy)
+    with ProcessPoolExecutor(max_workers=workers) as ex:
+        futures = [ex.submit(_probe_file, t) for t in tasks]
+        for fut in as_completed(futures):
+            status, v, d, h, path_str = fut.result()
+            if status == "missing":
+                ef = ExpectedFile(v, d, h, Path(path_str))
+                missing.append(ef)
+                logger.debug("Missing: %s", path_str)
+            elif status == "unreadable":
+                ef = ExpectedFile(v, d, h, Path(path_str))
+                unreadable.append(ef)
+                logger.debug("Unreadable: %s", path_str)
+            else:
+                logger.debug("OK: %s", path_str)
+
+    logger.info("Check complete. Missing=%d, Unreadable=%d", len(missing), len(unreadable))
+    return missing, unreadable
+
+# ---------- Reporting ----------
+def print_summary(
+    root: Path,
+    variables: List[str],
+    yyyymmdds: List[str],
+    hours: List[str],
+    missing: List[ExpectedFile],
+    unreadable: List[ExpectedFile],
+) -> None:
+    total_expected = len(variables) * len(yyyymmdds) * len(hours)
+    print("=" * 72)
+    print(f"Root: {root}")
+    print(f"Variables: {len(variables)}")
+    print(f"Dates: {yyyymmdds[0]} .. {yyyymmdds[-1]}  (count={len(yyyymmdds)})")
+    print(f"Hours: {','.join(hours)}  (count={len(hours)})")
+    print(f"Total expected files: {total_expected}")
+    print(f"Missing: {len(missing)}")
+    print(f"Unreadable (strict): {len(unreadable)}")
+    print("=" * 72)
+
+    if missing:
+        by_dt: Dict[Tuple[str, str], List[str]] = {}
+        for f in missing:
+            by_dt.setdefault((f.yyyymmdd, f.hh), []).append(f.variable)
+        print("\nTop missing slots (date/hour) with variable counts:")
+        for (d, h), vars_ in sorted(by_dt.items(), key=lambda kv: len(kv[1]), reverse=True)[:20]:
+            print(f"  {d} {h}: {len(vars_)} vars missing")
+
+def export_csv(csv_path: Path, rows: List[ExpectedFile], label: str) -> None:
+    if not rows:
+        return
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    import csv
+    with csv_path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["type", "variable", "yyyymmdd", "hh", "path"])
+        for r in rows:
+            w.writerow([label, r.variable, r.yyyymmdd, r.hh, str(r.path)])
+
+# ---------- Main ----------
+def main(argv: Optional[List[str]] = None) -> int:
+    p = argparse.ArgumentParser(description="Check missing RWRF NPZ files over a date/hour range (parallel).")
+    p.add_argument("--root", required=True, help="Directory containing NPZ files.")
+    p.add_argument("--start-date", required=True, help="YYYY/MM/DD")
+    p.add_argument("--end-date", required=True, help="YYYY/MM/DD")
+    p.add_argument("--hours", required=True, help="Comma-separated hours, e.g. 00,06,12,18 or 00,01,...,23")
+    p.add_argument("--variables", default=None, help="Comma-separated variable IDs. Defaults to built-in list.")
+    p.add_argument("--csv-out", default=None, help="Optional CSV path to write a detailed missing list.")
+    p.add_argument("--csv-unreadable-out", default=None, help="Optional CSV path for unreadable (when --strict).")
+    p.add_argument("--strict", action="store_true", help="Try opening each NPZ to detect corrupt/unreadable files.")
+    p.add_argument("--workers", type=int, default=multiprocessing.cpu_count(), help="Process pool size.")
+    p.add_argument("--log-level", default="INFO", choices=["DEBUG","INFO","WARNING","ERROR"], help="Logger level.")
+    args = p.parse_args(argv)
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s %(levelname)s %(name)s:%(lineno)d: %(message)s"
+    )
+
+    root = Path(args.root)
+    if not root.is_dir():
+        print(f"ERROR: root not found or not a directory: {root}", file=sys.stderr)
+        return 2
+
+    try:
+        hours = parse_hours(args.hours)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    try:
+        variables = parse_variables(args.variables)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    yyyymmdds = date_range_inclusive(args.start_date, args.end_date)
+    files = expected_files(root, variables, yyyymmdds, hours)
+
+    missing, unreadable = check_files_mp(files, strict=args.strict, workers=args.workers)
+
+    print_summary(root, variables, yyyymmdds, hours, missing, unreadable)
+
+    if args.csv_out:
+        export_csv(Path(args.csv_out), missing, label="missing")
+        print(f"Wrote missing CSV: {args.csv_out}")
+    if args.csv_unreadable_out and args.strict:
+        export_csv(Path(args.csv_unreadable_out), unreadable, label="unreadable")
+        print(f"Wrote unreadable CSV: {args.csv_unreadable_out}")
+
+    # Non-zero exit if anything is missing or unreadable
+    return 1 if (missing or unreadable) else 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dev/rwrf_process/des_process_rwrf_qpe/check_rwrf_npz_missing.sh
+++ b/dev/rwrf_process/des_process_rwrf_qpe/check_rwrf_npz_missing.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# All hours (no spaces between commas!)
+python check_rwrf_npz_missing.py \
+  --root <path_to_rwrf_npz_dir>\
+  --start-date 2019/08/01 \
+  --end-date   2022/09/01 \
+  --hours 00,01,02,03,04,05,06,07,08,09,10,11,12,13,14,15,16,17,18,19,20,21,22,23 \
+  --csv-out missing.csv \

--- a/dev/rwrf_process/des_process_rwrf_qpe/rwrf_lite_mp.py
+++ b/dev/rwrf_process/des_process_rwrf_qpe/rwrf_lite_mp.py
@@ -1,0 +1,174 @@
+import logging
+import os
+import pathlib
+from datetime import datetime, timedelta
+import shutil
+import yaml
+
+from rwrf_qpepre_processor_mp import RWRFQPEPREProcessor
+from rwrf_mp import RWRF
+from concurrent.futures import ProcessPoolExecutor, as_completed
+
+logger = logging.getLogger("rwrf")
+
+def create_datestrs(date_list):
+    """
+    date_list: ["YYYY/MM/DD", "YYYY/MM/DD"]
+    returns:   ["YYYY/MM/DD", "YYYY/MM/DD", ...] inclusive
+    """
+    fmt = "%Y/%m/%d"
+    start = datetime.strptime(date_list[0], fmt).date()
+    end   = datetime.strptime(date_list[1], fmt).date()
+
+    if start > end:
+        start, end = end, start
+
+    return [(start + timedelta(days=i)).strftime(fmt)
+            for i in range((end - start).days + 1)]
+class RWRFLite:
+    def __init__(
+        self,
+        qpepre_nc_src: str,
+        npz_folder: str,
+        qpepre_src: str,
+        rwrf_src: str,
+        overwrite: bool = False,
+    ):
+        self.rwrf_qpepre_processor = RWRFQPEPREProcessor(
+            qpepre_src=qpepre_src, rwrf_src=rwrf_src, output_dir=qpepre_nc_src
+        )
+        self.rwrf = RWRF(
+            nc_folder=qpepre_nc_src,
+            npz_folder=npz_folder,
+            overwrite=overwrite,
+        )
+    
+    def process_one(self, date_str: str, hr_str: str):
+        """One independent unit of work for multiprocessing"""
+        if self.rwrf._check_exists(date_str, hr_str):
+            logger.debug(f"Converted npz already exists for {date_str} {hr_str}, skipping.")
+            return
+
+        logger.debug(f"Processing {date_str} {hr_str}...")
+        self.rwrf_qpepre_processor._process(date_str, hr_str)
+
+        logger.debug("Converting RWRF NetCDF to NPZ")
+        nc_path = self.get_rwrf_path(date_str, hr_str)
+        self.rwrf.convert_to_npz(nc_path)
+        # if nc_path.suffix == ".nc":
+        #     self.remove_temp_files(nc_path, remove_parent=True, force_parent=True)
+
+
+    def process_files_from_date_list(self, date_strs: list[str], hr_strs: list[str], workers: int = 240) -> None:
+        tasks = [(d, h) for d in date_strs for h in hr_strs]
+
+        with ProcessPoolExecutor(max_workers=workers) as executor:
+            futures = {executor.submit(self.process_one, d, h): (d, h) for d, h in tasks}
+            for fut in as_completed(futures):
+                d, h = futures[fut]
+                try:
+                    fut.result()
+                    logger.info(f"Finished {d} {h}")
+                except Exception as e:
+                    logger.error(f"Failed {d} {h}: {e}")
+
+        # save timing at the end
+        self.rwrf_qpepre_processor.save_time_records("./timings.csv", fmt="csv")
+
+    # def process_files_from_date_list(
+    #     self, date_strs: list[str], hr_strs: list[str]
+    # ) -> None:
+    #     """
+    #     Executes the processing workflow for a given list of dates and hours.
+
+    #     Parameters
+    #     ----------
+    #     date_strs : list[str]
+    #         A list of date strings in 'YYYY/MM/DD' format.
+    #     hr_strs : list[str]
+    #         A list of hour strings in 'HH' format (e.g., '00', '12', '23').
+    #     """
+    #     for date_str in date_strs:
+    #         for hr_str in hr_strs:
+    #             if self.rwrf._check_exists(date_str, hr_str):
+    #                 logger.debug(
+    #                     f"Converted npz files already exists for RWRF  {date_str} {hr_str}, skipping conversion."
+    #                 )
+    #                 continue
+
+    #             logger.debug(
+    #                 f"Queueing RWRF-QPEPRE processing for {date_str} {hr_str}..."
+    #             )
+    #             self.rwrf_qpepre_processor._process(date_str, hr_str)
+
+    #             logger.debug("Converting RWRF NetCDF to NPZ")
+    #             nc_path = self.get_rwrf_path(date_str, hr_str) # if nc file doesn't have its corresponding qpepre file will just return original nc file path (doesn't have .nc suffix)
+    #             self.rwrf.convert_to_npz(nc_path)
+    #             if nc_path.suffix == ".nc":
+    #                 self.remove_temp_files(nc_path, remove_parent=True, force_parent=True)
+
+    #     self.rwrf_qpepre_processor.save_time_records("./timings.csv", fmt="csv")
+            
+    def get_rwrf_path(self, date_str: str, hr_str: str) -> pathlib.Path:
+        """Constructs the path to the NetCDF file for a given date and hour.
+        Parameters
+        ----------
+        date_str : str
+            The date string in 'YYYY/MM/DD' format.
+        hr_str : str
+            The hour string in 'HH' format (e.g., '00', '12', '23').
+
+        Returns
+        -------
+        str
+            The path to the NetCDF file for the specified date and hour.
+        """
+        org_path, new_path = self.rwrf_qpepre_processor._get_rwrf_paths(date_str, hr_str)
+        cropped_path = new_path.replace("qpepre.nc", "cropped_qpepre.nc")
+        if not os.path.exists(cropped_path):
+            logger.warning(f"Processed RWRF-QPEPRE file {cropped_path} doesn't exist, using original RWRF file {org_path}")
+            return pathlib.Path(org_path)
+
+        return pathlib.Path(cropped_path)
+    
+    def remove_temp_files(
+        self,
+        nc_path: pathlib.Path,
+        remove_parent: bool = True,
+        force_parent: bool = False,
+        ) -> None:
+        """Removes temporary files created during processing.
+        Parameters
+        ----------
+        nc_path : pathlib.Path
+            The path to the NetCDF file that was processed.
+        Raises
+        ------
+        FileNotFoundError
+            If the specified NetCDF file does not exist.              
+        """
+        if not nc_path.exists():
+            logger.warning(f"Temporary file not found, skipping removal: {nc_path}")
+        else:
+            try:
+                nc_path.unlink()  # os.remove works too, but Path is cleaner
+                logger.debug("Removed temporary file: %s", nc_path)
+            except Exception as e:
+                logger.error("Error removing temporary file %s: %s", nc_path, e)
+                raise
+
+        if remove_parent:
+            parent = nc_path.parent
+            try:
+                if force_parent:
+                    shutil.rmtree(parent)
+                    logger.debug("Removed parent directory recursively: %s", parent)
+                else:
+                    parent.rmdir()  # only succeeds if the directory is empty
+                    logger.debug("Removed empty parent directory: %s", parent)
+            except FileNotFoundError:
+                logger.warning("Parent directory not found, skipping: %s", parent)
+            except OSError as e:
+                # Commonly: Directory not empty when force_parent=False
+                logger.debug("Did not remove parent directory %s: %s", parent, e)
+

--- a/dev/rwrf_process/des_process_rwrf_qpe/rwrf_mp.py
+++ b/dev/rwrf_process/des_process_rwrf_qpe/rwrf_mp.py
@@ -1,0 +1,316 @@
+import logging
+import pathlib
+from datetime import datetime
+import netCDF4 as nc
+import numpy as np
+import xarray as xr
+from pathlib import Path
+import sys
+
+PARENT = Path(__file__).resolve().parent.parent
+if str(PARENT) not in sys.path:
+    sys.path.insert(0, str(PARENT))
+
+
+from lexicon import RWRFLexicon
+
+logger = logging.getLogger("rwrf")
+
+PRES_IDX = {
+    1000: 0,
+    925: 3,
+    850: 6,
+    700: 11,
+    600: 13,
+    500: 15,
+    400: 17,
+    300: 19,
+    250: 20,
+    200: 22,
+    150: 24,
+    100: 26,
+    50: 28,
+}
+
+VARIABLES = [
+    "u10",
+    "v10",
+    "t2m",
+    "sp",
+    "msl",
+    "tcwv",
+    "u50",
+    "u100",
+    "u150",
+    "u200",
+    "u250",
+    "u300",
+    "u400",
+    "u500",
+    "u600",
+    "u700",
+    "u850",
+    "u925",
+    "u1000",
+    "v50",
+    "v100",
+    "v150",
+    "v200",
+    "v250",
+    "v300",
+    "v400",
+    "v500",
+    "v600",
+    "v700",
+    "v850",
+    "v925",
+    "v1000",
+    "z50",
+    "z100",
+    "z150",
+    "z200",
+    "z250",
+    "z300",
+    "z400",
+    "z500",
+    "z600",
+    "z700",
+    "z850",
+    "z925",
+    "z1000",
+    "t50",
+    "t100",
+    "t150",
+    "t200",
+    "t250",
+    "t300",
+    "t400",
+    "t500",
+    "t600",
+    "t700",
+    "t850",
+    "t925",
+    "t1000",
+    "q50",
+    "q100",
+    "q150",
+    "q200",
+    "q250",
+    "q300",
+    "q400",
+    "q500",
+    "q600",
+    "q700",
+    "q850",
+    "q925",
+    "q1000",
+    "qpepre",
+    "lsm",
+    "orog",
+]
+
+
+class RWRF:
+    """Local RWRF datasource that reads NetCDF files asynchronously and saves them
+    to NPZ format. The output folder acts as a cache.
+
+    Parameters
+    ----------
+    nc_folder : str
+        The root directory where source NetCDF files are stored.
+        Expected structure: `{nc_folder}/{YYYY}-{MM}-{DD}_{HH}/wrfout_d01_{YYYY}-{MM}-{DD}_{HH}_interp_cropped_qpepre.nc`
+    npz_folder : str
+        The directory where output NPZ files will be saved. This acts as a cache.
+    verbose : bool, optional
+        If True, shows a progress bar during conversion. By default True.
+    overwrite: bool, optional
+        If True, overwrites existing NPZ files. By default False.
+    """
+
+    def __init__(
+        self,
+        nc_folder: str,
+        npz_folder: str,
+        overwrite: bool = False,
+    ):
+        self.nc_folder = pathlib.Path(nc_folder)
+        self.npz_folder = pathlib.Path(npz_folder)
+        self._overwrite = overwrite
+        self.lexicon = RWRFLexicon
+
+        if not self.nc_folder.is_dir():
+            raise FileNotFoundError(f"Input NetCDF folder not found: {nc_folder}")
+
+        self.npz_folder.mkdir(parents=True, exist_ok=True)
+
+        logger.info(f"RWRF source directory: {self.nc_folder}")
+
+    def __call__(self) -> None:
+        """Function to get data"""
+        self.process_files()
+
+    def process_files(self) -> None:
+        """Asynchronously converts all NetCDF files in the folder to NPZ format."""
+        nc_files = list(self.nc_folder.rglob("*_cropped_qpepre.nc"))
+        logger.info("Converting RWRF NetCDF to NPZ")
+        for nc_file in nc_files:
+            print(f"Next: {nc_file}")
+            self.convert_to_npz(nc_file)
+
+    def convert_to_npz(self, nc_path: pathlib.Path) -> None:
+        """Loads a single NetCDF file and creates concurrent tasks to save each
+        variable to a separate NPZ file.
+
+        Parameters
+        ----------
+        nc_path : pathlib.Path
+            The path to the NetCDF file to convert.
+        """
+        if not nc_path.exists():
+            logger.warning(f"NetCDF file not found, skipping: {nc_path}")
+            return
+
+        try:
+            with nc.Dataset(nc_path) as ds:
+                # Extract date string from filename: wrfout_d01_{YYYY}-{MM}-{DD}_{HH}_interp_cropped_qpepre.nc or wrfout_d01_{YYYY}-{MM}-{DD}_{HH}_interp
+                basename = nc_path.stem
+                if not (
+                    basename.startswith("wrfout_d01_")
+                    and (basename.endswith("_interp_cropped_qpepre") or basename.endswith("_interp"))
+                ):
+                    logger.error(f"Filename format not recognized: {basename}")
+                    return
+                if basename.endswith("_interp_cropped_qpepre"):
+                    date_str = basename[11:-22].replace("_", "").replace("-", "")
+                else:
+                    date_str = basename[11:-7].replace("_", "").replace("-", "")
+                lat = ds.variables["XLAT"][:]
+                lon = ds.variables["XLONG"][:]
+                times = ds.variables["Times"][:]
+
+                for var in VARIABLES:
+                    logger.info(f"converting {var}.nc to npz")
+                    rwrf_name, modifier = self.lexicon[var]
+                    if rwrf_name not in ds.variables:
+                        logger.warning(
+                            f"Key '{rwrf_name}' not found in rwrf {nc_path}, skipping {rwrf_name} .npz conversion"
+                        )
+                        continue
+                    if ds.variables[rwrf_name].ndim == 3:
+                        data = ds.variables[rwrf_name][:]
+                    else:
+                        level = int(var[1:])
+                        data = ds.variables[rwrf_name][:, PRES_IDX[level], :, :]
+                    data = modifier(data)
+                    self._save_variable_npz(var, date_str, lat, lon, times, data)
+                    logger.info(f"converting {var}.nc to npz done.")
+
+        except Exception as e:
+            logger.error(f"Error processing file {nc_path}: {e}")
+            return
+
+    def _save_variable_npz(
+        self,
+        variable_id: str,
+        date_str: str,
+        lat: np.ndarray,
+        lon: np.ndarray,
+        times: np.ndarray,
+        data: np.ndarray,
+    ) -> None:
+        """Saves data of a single variable to an NPZ file.
+
+        Parameters
+        ----------
+        ds : nc.Dataset
+            The NetCDF dataset containing the variable to save.
+        variable_id : str
+            The ID of the variable to save.
+        date_str : str
+            The date string extracted from the filename.
+        lat : np.ndarray
+            The latitude array.
+        lon : np.ndarray
+            The longitude array.
+        times : np.ndarray
+            The time array.
+        data: np.ndarray
+            The data array to save.
+        """
+        try:
+            fn = f"{variable_id}_{date_str}.npz"
+            out_path = self.npz_folder / fn
+            if not self._overwrite and out_path.exists():
+                logger.debug(f"File exists, skipping: {out_path}")
+                return
+
+            np.savez(out_path, **{variable_id: data}, lat=lat, lon=lon, times=times)
+            logger.debug(f"Successfully saved {out_path}")
+        except Exception as e:
+            logger.error(f"Failed to save NPZ file {out_path}: {e}")
+            return
+
+    def _check_exists(self, date_str: str, hr_str: str) -> bool:
+        """Checks if the NPZ file for the given date and hour already exists.
+
+        Parameters
+        ----------
+        date_str : str
+            The date string in the format YYYYMMDD.
+        hr_str : str
+            The hour string in the format HH.
+
+        Returns
+        -------
+        bool
+            True if the NPZ file exists, False otherwise.
+        """
+        missing_vars = []
+        dt = datetime.strptime(date_str, "%Y/%m/%d")
+        date_str = dt.strftime("%Y%m%d")
+        hr_str = hr_str.zfill(2)  # Ensure hour is two digits
+
+        for var in VARIABLES:
+            fn = f"{var}_{date_str}{hr_str}.npz"
+            out_path = self.npz_folder / fn
+            logger.debug(f"Checking existence of {out_path}")
+            if not out_path.exists():
+                missing_vars.append(var)
+        if not missing_vars:
+            logger.info(f"All NPZ files exist for {date_str} {hr_str}") # change to debug level?
+            return True
+        else:
+            logger.info(f"Missing NPZ files for {date_str} {hr_str}: {missing_vars}") # change to debug level?
+            return False
+    
+    @property
+    def info(self) -> None:
+        """Prints info about the data source."""
+        try:
+            nc_files = list(self.nc_folder.rglob("*.nc"))
+            if not nc_files:
+                logger.warning("No NetCDF files found to read info from.")
+                return
+
+            first_nc = nc_files[0]
+            with xr.open_dataset(
+                first_nc, decode_coords=True, mask_and_scale=False
+            ) as ds:
+                logger.debug("RWRF dataset global attributes:")
+                for k, v in ds.attrs.items():
+                    logger.debug(f"{k}: {v}")
+
+                logger.debug("RWRF dataset dimensions:")
+                for k, v in ds.sizes.items():
+                    logger.debug(f"{k}: {v}")
+
+                logger.debug("RWRF dataset variables:")
+                for k, v in ds.variables.items():
+                    if k == "pres_levels":
+                        logger.debug(f"{k}: {v}\n{v.values} (pressure levels in hPa)")
+                    else:
+                        logger.debug(f"{k}: {v}")
+
+        except Exception as e:
+            logger.error(f"Could not read info from NetCDF file: {e}")
+            raise e

--- a/dev/rwrf_process/des_process_rwrf_qpe/rwrf_nc_2_npz.sh
+++ b/dev/rwrf_process/des_process_rwrf_qpe/rwrf_nc_2_npz.sh
@@ -1,0 +1,9 @@
+python3 rwrf_nc_2_npz_wrapper.py \
+    --rwrf-src <path_to_rwrf_nc_scr_dir> \
+    --qpepre-src <path_to_qpepre_txt_dir> \
+    --npz-folder <dir_path_to_store_npz_> \
+    --qpepre-nc-src <dir_path_to_store_qpepre_nc> \
+    --start-date 2019/08/01 \
+    --end-date 2021/09/01 \
+    --hours 00,01,02,03,04,05,06,07,08,09,10,11,12,13,14,15,16,17,18,19,20,21,22,23 
+

--- a/dev/rwrf_process/des_process_rwrf_qpe/rwrf_nc_2_npz_wrapper.py
+++ b/dev/rwrf_process/des_process_rwrf_qpe/rwrf_nc_2_npz_wrapper.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+run_rwrf_lite.py
+
+Command-line wrapper for RWRFLite (mp or base).
+
+NO CONFIG IMPORTS — all inputs are provided via CLI.
+
+Features
+- Paths: --rwrf-src, --qpepre-src, --qpepre-nc-src, --npz-folder
+- Date range: --start-date, --end-date (inclusive, YYYY/MM/DD)
+- Hours: --hours "00,06,12,18" (required)
+- Concurrency: --workers
+- Overwrite: --overwrite
+- Logging: --log-level, --log-file
+- Writes run metadata JSON into the output folder
+"""
+
+import argparse
+import json
+import logging
+import os
+import pathlib
+import sys
+from datetime import datetime
+from typing import List
+import multiprocessing
+
+from rwrf_lite_mp import RWRFLite, create_datestrs  
+import time
+
+def setup_logging(level: str, log_file: str | None):
+    handlers = [logging.StreamHandler(sys.stdout)]
+    if log_file:
+        handlers.append(logging.FileHandler(log_file, mode="a", encoding="utf-8"))
+
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s:%(lineno)d: %(message)s",
+        handlers=handlers,
+    )
+logger = logging.getLogger("rwrf")
+setup_logging("DEBUG", "rwrf_qpe_nc_2_npz_log.txt")
+
+def parse_hours(hours_str: str) -> List[str]:
+    """Parse required comma-separated hours into zero-padded HH list."""
+    parts = [p.strip() for p in hours_str.split(",") if p.strip() != ""]
+    if not parts:
+        raise ValueError("`--hours` is required and must be non-empty, e.g. 00,06,12,18")
+    hrs = []
+    for p in parts:
+        if not p.isdigit():
+            raise ValueError(f"Invalid hour '{p}': must be 0..23")
+        v = int(p)
+        if not (0 <= v <= 23):
+            raise ValueError(f"Invalid hour '{p}': must be 0..23")
+        hrs.append(f"{v:02d}")
+    return hrs
+
+
+def ensure_dir(p: str | pathlib.Path) -> pathlib.Path:
+    path = pathlib.Path(p)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def setup_logging(level: str, log_file: str | None):
+    handlers = [logging.StreamHandler(sys.stdout)]
+    if log_file:
+        handlers.append(logging.FileHandler(log_file))
+    logging.basicConfig(
+        level=getattr(logging, level),
+        format="%(asctime)s %(levelname)s %(name)s:%(lineno)d: %(message)s",
+        handlers=handlers,
+    )
+
+
+def dump_metadata(meta_path: pathlib.Path, payload: dict):
+    try:
+        with meta_path.open("w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2, ensure_ascii=False)
+    except Exception as e:
+        logger.warning("Failed to write metadata: %s", e)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run RWRFLite over a configurable date/hour range.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--rwrf-src", required=True, help="Path to raw RWRF source directory")
+    parser.add_argument("--qpepre-src", required=True, help="Path to QPEPRE source directory")
+    parser.add_argument("--start-date", required=True, help="Start date (YYYY/MM/DD)")
+    parser.add_argument("--end-date", required=True, help="End date (YYYY/MM/DD)")
+    parser.add_argument("--hours", required=True, help="Comma-separated hours, e.g. '00,06,12,18'")
+    parser.add_argument("--qpepre-nc-src", required=True, help="Temporary working directory for NetCDFs")
+    parser.add_argument("--npz-folder", required=True, help="Output NPZ cache directory root")
+    parser.add_argument("--workers", type=int, default=multiprocessing.cpu_count(), help="Max workers for ProcessPoolExecutor")
+    parser.add_argument("--overwrite", action="store_true", help="Overwrite existing outputs")
+
+    args = parser.parse_args(argv)
+
+    # Start timer
+    t0 = time.perf_counter()
+
+    # Resolve hours and dates
+    try:
+        hr_strs = parse_hours(args.hours)
+    except ValueError as e:
+        logger.error(str(e))
+        return 2
+    date_strs = create_datestrs([args.start_date, args.end_date])
+    if not date_strs:
+        logger.error("Empty date range after parsing; check --start-date/--end-date.")
+        return 2
+
+    # Prepare directories
+    qpere_nc_src = ensure_dir(args.qpepre_nc_src)
+    out_root = ensure_dir(args.npz_folder)
+    out_dir = ensure_dir(out_root)
+
+    # Instantiate pipeline (all config comes from CLI here)
+    rwrf_lite = RWRFLite(
+        qpepre_src=args.qpepre_src,
+        rwrf_src=args.rwrf_src,
+        qpepre_nc_src=str(args.qpepre_nc_src),
+        npz_folder=str(out_dir),
+        overwrite=args.overwrite,
+    )
+
+
+    logger.debug("Dates: %s", date_strs)
+    logger.debug("Hours: %s", hr_strs)
+    logger.debug("RWRF src: %s | QPEPRE src: %s", args.rwrf_src, args.qpepre_src)
+    logger.debug("qpepre-nc-src: %s | npz-folder: %s", qpere_nc_src, out_dir)
+
+    # Persist run metadata
+    run_meta = {
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "rwrf_src": str(args.rwrf_src),
+        "qpepre_src": str(args.qpepre_src),
+        "tmp_src": str(qpere_nc_src),
+        "npz_folder": str(out_dir),
+        "start_date": args.start_date,
+        "end_date": args.end_date,
+        "hours": hr_strs,
+        "workers": args.workers,
+        "overwrite": args.overwrite,
+        "cmdline": " ".join(sys.argv),
+    }
+    dump_metadata(out_dir / "run_metadata.json", run_meta)
+
+    # Run
+    try:
+        rwrf_lite.process_files_from_date_list(date_strs, hr_strs, workers=args.workers)
+    except KeyboardInterrupt:
+        logger.warning("Interrupted by user.")
+        return 130
+    except Exception as e:
+        logger.exception("Pipeline failed: %s", e)
+        return 1
+
+    elapsed = time.perf_counter() - t0
+    mins, secs = divmod(elapsed, 60)
+    logger.info("Total runtime: %.1f seconds (%.1f minutes)", elapsed, mins + secs/60)
+    logger.info("Completed successfully. Output: %s", out_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dev/rwrf_process/des_process_rwrf_qpe/rwrf_qpepre_processor_mp.py
+++ b/dev/rwrf_process/des_process_rwrf_qpe/rwrf_qpepre_processor_mp.py
@@ -1,0 +1,501 @@
+import logging
+import os
+import pathlib
+from datetime import datetime, timedelta
+import time
+import csv
+import json
+import csv
+
+import numpy as np
+import regex as re
+from netCDF4 import Dataset
+from scipy.interpolate import griddata
+
+logger = logging.getLogger("rwrf")
+
+class RWRFQPEPREProcessor:
+    """
+    Processes and interpolates/combines RWRF data with QPEPRE data.
+
+    Parameters
+    ----------
+    output_dir : str
+        The directory where the output files will be saved.
+    qpepre_src : str
+        The directory where the QPEPRE input files are located.
+    rwrf_src : str
+        The directory where the RWRF input files are located.
+    """
+
+    def __init__(
+        self,
+        output_dir: str,
+        qpepre_src: str,
+        rwrf_src: str,
+        perf_dir: str | None = None, 
+    ):
+        self.qpepre_src = pathlib.Path(qpepre_src)
+        self.rwrf_src   = pathlib.Path(rwrf_src)      # <-- make Path
+        self.output_dir = pathlib.Path(output_dir)    # <-- make Path
+        self.output_dir.mkdir(parents=True, exist_ok=True) # redundant?
+        
+        # ensure "rwrf" subdirectory inside output_dir
+        self.output_rwrf_dir = self.output_dir / "rwrf"
+        self.output_rwrf_dir.mkdir(parents=True, exist_ok=True)
+
+        # for performance measurement
+        self.time_records: dict[str, float] = {
+            "txt_to_nc": 0.0,
+            "combine": 0.0,
+            "crop": 0.0,
+            "find_rwrf_paths": 0.0,
+            "total": 0.0,
+        }
+
+        # build index of RWRF files once
+        self._rwrf_index: dict[str, pathlib.Path] = {}
+        self._build_rwrf_index()
+
+
+    def __call__(self):
+        """
+        Interpolates all QPEPRE files in the source directory into corresponding RWRF datasets.
+        Handles filenames like: qpepre_YYYYMMDDHHMM-YYYYMMDDHHMM_1_h.txt
+        """
+        src_path = pathlib.Path(self.qpepre_src)
+        qpepre_files = list(src_path.rglob("*.txt"))
+
+        # regex: capture the first 12-digit timestamp after 'qpepre_'
+
+        pat = re.compile(r"qpepre_(\d{12})-\d{12}_1_h(?:\.txt)?$")
+
+        for file in qpepre_files:
+            m = pat.search(file.name)
+            if not m:
+                logger.debug(f"Skip (unrecognized name): {file}")
+                continue
+
+            start_str = m.group(1)      # YYYYMMDDHHMM
+            y, mth, d, hh = start_str[0:4], start_str[4:6], start_str[6:8], start_str[8:10]
+            date_str = f"{y}/{mth}/{d}"
+            hr_str = hh
+
+            if self._check_exists(date_str, hr_str):
+                logger.debug(f"RWRF QPEPRE dataset already exists for {date_str} {hr_str}. Skipping.")
+                continue
+
+            self._process(date_str, hr_str)
+
+    def _build_rwrf_index(self) -> None:
+        """
+        Scan the rwrf_src folder once and index wrfout files by their parent folder name
+        (e.g., 'YYYY-MM-DD_HH').
+        """
+        t0 = time.perf_counter()
+        logger.info(f"Building RWRF index under {self.rwrf_src}...")
+        for p in self.rwrf_src.rglob("wrfout_d01_*_interp"):
+            key = p.parent.name  # e.g. '2020-07-01_12'
+            self._rwrf_index[key] = p
+        logger.info(f"Indexed {len(self._rwrf_index)} RWRF files.")
+        t1 = time.perf_counter()
+        self.time_records["find_rwrf_paths"] += (t1 - t0)
+
+    def _resolve_qpepre_dir_for_year(self, year: int) -> pathlib.Path | None:
+        """
+        Return the subdirectory under qpepre_src that holds files for `year`.
+        Checks: <root>/<year>/  then  <root>/forai_1hrobs_<year>/
+        Falls back to None if neither exists.
+        """
+        # Common cases based on your layout
+        logger.debug(f"Resolving QPEPRE directory for year: {year}")
+        cand1 = self.qpepre_src / f"{year}"
+        cand2 = self.qpepre_src / f"forai_1hrobs_{year}"
+        logger.debug("resolve done")
+        if cand1.is_dir():
+            return cand1
+        if cand2.is_dir():
+            return cand2
+        return None
+
+    def process_files_from_date_list(
+        self, date_strs: list[str], hr_strs: list[str]
+    ) -> None:
+        """
+        Executes the processing workflow for a given list of dates and hours.
+
+        Parameters
+        ----------
+        date_strs : list[str]
+            A list of date strings in 'YYYY/MM/DD' format.
+        hr_strs : list[str]
+            A list of hour strings in 'HH' format (e.g., '00', '12', '23').
+        """
+        logger.info(f"Processing files for dates: {date_strs} and hours: {hr_strs}")
+        for date_str in date_strs:
+            for hr_str in hr_strs:
+                if self._check_exists(date_str, hr_str):
+                    logger.debug(
+                        f"Converted file already exists for QPEPRE {date_str} {hr_str}, skipping conversion."
+                    )
+                    continue
+
+                logger.debug(
+                    f"Queueing RWRF-QPEPRE processing for {date_str} {hr_str}..."
+                )
+                self._process(date_str, hr_str)
+
+    def _get_qpepre_filename_from_date(self, date_str: str, hr_str: str) -> str:
+        """
+        Return the *stem* path (without '.txt') to the QPEPRE file for the given date/hour.
+        This handles different per-year folder names and falls back to a recursive search.
+        """
+        logger.debug(f"Getting QPEPRE filename for date: {date_str}, hour: {hr_str}")
+        dt_end = datetime.strptime(f"{date_str} {hr_str}", "%Y/%m/%d %H")
+        dt_start = dt_end - timedelta(hours=1)
+
+        start_str = dt_start.strftime("%Y%m%d%H%M")
+        end_str = dt_end.strftime("%Y%m%d%H%M")
+        filename = f"qpepre_{start_str}-{end_str}_1_h"
+        year = dt_start.year
+
+        # 1) Try expected subfolder(s) for the year
+        year_dir = self._resolve_qpepre_dir_for_year(year)
+        if year_dir:
+            candidate = year_dir / f"{filename}.txt"
+            if candidate.exists():
+                # Return path *without* extension, to match existing call sites
+                return str(candidate.with_suffix(""))
+
+        # 2) Fallback: recursive search under the whole root
+        matches = list(self.qpepre_src.rglob(f"{filename}.txt"))
+        if matches:
+            return str(matches[0].with_suffix(""))
+
+        # 3) Give a helpful error
+        raise FileNotFoundError(
+            f"QPEPRE file not found for {date_str} {hr_str}. "
+            f"Tried: {self.qpepre_src}/{{{year}, forai_1hrobs_{year}}}/{filename}.txt"
+        )
+
+    # def _get_rwrf_paths(self, date_str: str, hr_str: str) -> tuple[str, str]:
+    #     """Gets the original RWRF file path and the path for the new processed file.
+
+    #     Parameters
+    #     ----------
+    #     date_str : str
+    #         The date string in 'YYYY/MM/DD' format.
+    #     hr_str : str
+    #         The hour string in 'HH' format (e.g., '00', '12', '23').
+
+    #     Returns
+    #     -------
+    #     tuple[str, str]
+    #         The original RWRF file path and the path for the new processed file.
+    #     """
+    #     dt = datetime.strptime(date_str, "%Y/%m/%d")
+    #     fmt_dt_str = dt.strftime(f"%Y-%m-%d_{int(hr_str):02d}")
+        
+    #     base = pathlib.Path(self.rwrf_src)
+    #     matches = list(base.rglob(fmt_dt_str))
+    #     if not matches:
+    #         logger.warning(f"No matching RWRF files found for {date_str} {hr_str}")
+    #         org_path = f"{self.rwrf_src}/{fmt_dt_str}/wrfout_d01_{fmt_dt_str}_interp" # dummy path
+    #     else:
+    #         target_folder = matches[0]
+    #         org_path = str(target_folder / f"wrfout_d01_{fmt_dt_str}_interp")
+            
+    #     new_path = (
+    #         f"{self.output_dir}/{fmt_dt_str}/wrfout_d01_{fmt_dt_str}_interp_qpepre.nc"
+    #     )
+    #     return org_path, new_path
+    
+    def _get_rwrf_paths(self, date_str: str, hr_str: str) -> tuple[str, str]:
+        """Gets the original RWRF file path and the path for the new processed file.
+
+        Parameters
+        ----------
+        date_str : str
+            The date string in 'YYYY/MM/DD' format.
+        hr_str : str
+            The hour string in 'HH' format (e.g., '00', '12', '23').
+
+        Returns
+        -------
+        tuple[str, str]
+            The original RWRF file path and the path for the new processed file.
+        """
+        dt = datetime.strptime(date_str, "%Y/%m/%d")
+        fmt_dt_str = dt.strftime(f"%Y-%m-%d_{int(hr_str):02d}")
+
+        org_path = self._rwrf_index.get(fmt_dt_str)
+        if org_path is None:
+            logger.warning(f"No matching RWRF files found for {date_str} {hr_str}")
+            # fallback dummy path to maintain consistency
+            org_path = self.rwrf_src / fmt_dt_str / f"wrfout_d01_{fmt_dt_str}_interp"
+
+        new_path = self.output_dir / fmt_dt_str / f"wrfout_d01_{fmt_dt_str}_interp_qpepre.nc"
+        return str(org_path), str(new_path)
+    def _check_exists(self, date_str: str, hr_str: str) -> bool:
+        """Checks if the final cropped and combined file already exists.
+
+        Parameters
+        ----------
+        date_str : str
+            The date string in 'YYYY/MM/DD' format.
+        hr_str : str
+            The hour string in 'HH' format (e.g., '00', '12', '23').
+
+        Returns
+        -------
+        bool
+            True if the processed file exists, False otherwise.
+        """
+        _, new_path = self._get_rwrf_paths(date_str, hr_str)
+        cropped_path = new_path.replace("qpepre.nc", "cropped_qpepre.nc")
+        return os.path.exists(cropped_path)
+
+    def _convert_txt_to_nc(self, date_str: str, hr_str: str, var_name="qpepre") -> str:
+        """Converts a QPEPRE text file to a temporary NetCDF file.
+
+        Parameters
+        ----------
+        date_str : str
+            The date string in 'YYYY/MM/DD' format.
+        hr_str : str
+            The hour string in 'HH' format (e.g., '00', '12', '23').
+        var_name : str
+            The variable name to use in the NetCDF file.
+
+        Returns
+        -------
+        str
+            The path to the temporary NetCDF file.
+        """
+        filename = self._get_qpepre_filename_from_date(date_str, hr_str)
+        txt_path = filename + ".txt"
+        nc_path = self.output_dir / (pathlib.Path(filename).name + ".nc")
+
+        if not os.path.exists(txt_path):
+            raise FileNotFoundError(f"Source QPEPRE text file not found: {txt_path}")
+
+        data = np.loadtxt(txt_path)
+        match = re.search(r"(\d{12})-\d{12}", txt_path)
+        if not match:
+            raise ValueError(f"Filename does not match pattern: {txt_path}")
+        start_dt = datetime.strptime(match.group(1), "%Y%m%d%H%M")
+        start_str = start_dt.strftime("%Y-%m-%d_%H:%M:%S")
+
+        lon, lat, values = data[:, 1], data[:, 2], data[:, 3]
+        lat_unique, lon_unique = np.unique(lat), np.unique(lon)
+        n_lat, n_lon = len(lat_unique), len(lon_unique)
+
+        val_grid = np.full((1, n_lat, n_lon), np.nan, dtype=np.float32)
+        lat_grid = np.full((1, n_lat), np.nan, dtype=np.float32)
+        lon_grid = np.full((1, n_lon), np.nan, dtype=np.float32)
+        lat_to_idx = {lat: i for i, lat in enumerate(lat_unique)}
+        lon_to_idx = {lon: i for i, lon in enumerate(lon_unique)}
+
+        for i in range(data.shape[0]):
+            _lon, _lat, _val = data[i, 1], data[i, 2], data[i, 3]
+            lat_idx = lat_to_idx[_lat]
+            lon_idx = lon_to_idx[_lon]
+            val_grid[0, lat_idx, lon_idx] = _val
+
+        lat_grid[0, :] = lat_unique
+        lon_grid[0, :] = lon_unique
+
+        with Dataset(nc_path, "w", format="NETCDF4") as ds:
+            ds.createDimension("times", 1)
+            ds.createDimension("date_strlen", len(start_str))
+            ds.createDimension("lat", n_lat)
+            ds.createDimension("lon", n_lon)
+
+            times_var = ds.createVariable("times", "S1", ("times", "date_strlen"))
+            lat_var = ds.createVariable("lat", "f4", ("times", "lat"))
+            lon_var = ds.createVariable("lon", "f4", ("times", "lon"))
+            val_var = ds.createVariable(var_name, "f4", ("times", "lat", "lon"))
+
+            times_var[:] = np.array([list(start_str)], dtype="S1")
+            lat_var[:] = lat_grid
+            lon_var[:] = lon_grid
+            val_var[0, :, :] = val_grid
+
+        return nc_path
+
+    @staticmethod
+    def combine_rwrf_qpepre(
+        rwrf_ds: Dataset, qpepre_ds: Dataset, output_path: str
+    ) -> None:
+        """Create a new NetCDF file by copying all data and metadata from the RWRF dataset, then interpolating the QPEPRE data onto the RWRF grid and adding it as a new variable.
+
+        Parameters
+        ----------
+        rwrf_ds : Dataset
+            The source RWRF NetCDF dataset.
+        qpepre_ds : Dataset
+            The source QPEPRE NetCDF dataset to be interpolated and merged.
+        output_path : str
+            The file path where the combined NetCDF output will be saved.
+        """
+        with Dataset(output_path, "w", format=rwrf_ds.file_format) as dst:
+            for name, dim in rwrf_ds.dimensions.items():
+                dst.createDimension(name, len(dim) if not dim.isunlimited() else None)
+
+            for attr in rwrf_ds.ncattrs():
+                dst.setncattr(attr, rwrf_ds.getncattr(attr))
+
+            for name, var in rwrf_ds.variables.items():
+                out_var = dst.createVariable(name, var.datatype, var.dimensions)
+                for attr in var.ncattrs():
+                    out_var.setncattr(attr, var.getncattr(attr))
+                out_var[:] = var[:]
+
+            rwrf_lat2d, rwrf_lon2d = rwrf_ds["XLAT"][0, :], rwrf_ds["XLONG"][0, :]
+            qpepre_lat1d, qpepre_lon1d = qpepre_ds["lat"][:], qpepre_ds["lon"][:]
+            qpepre_var2d = qpepre_ds["qpepre"][0, :, :]
+            qpepre_lon2d, qpepre_lat2d = np.meshgrid(qpepre_lon1d, qpepre_lat1d)
+
+            points = np.column_stack((qpepre_lat2d.ravel(), qpepre_lon2d.ravel()))
+            values = qpepre_var2d.ravel()
+            target_points = np.column_stack((rwrf_lat2d.ravel(), rwrf_lon2d.ravel()))
+
+            interp_val = griddata(
+                points, values, target_points, method="linear", fill_value=0.0
+            )
+            interp_2d = interp_val.reshape(rwrf_lat2d.shape)
+
+            qpepre_var = dst.createVariable("qpepre", "f4", rwrf_ds["XLAT"].dimensions)
+            qpepre_var.description = (
+                "Precipitation from QPEPRE, interpolated to RWRF grid"
+            )
+            qpepre_var.units = "mm/hr"  # Needs verfication
+            qpepre_var[0, :, :] = interp_2d
+
+    def _crop_rwrf_by_qpepre(self, src_path: str) -> str:
+        """Crops a combined RWRF-QPEPRE file to the valid (non-NaN) data area of QPEPRE.
+
+        Parameters
+        ----------
+        src_path : str
+            The file path of the source combined RWRF-QPEPRE NetCDF file.
+
+        Returns
+        -------
+        str
+            The file path of the cropped NetCDF file.
+        """
+        cropped_path = src_path.replace("qpepre.nc", "cropped_qpepre.nc")
+
+        with Dataset(src_path, "r") as src, Dataset(cropped_path, "w") as dst:
+            qpepre = src.variables["qpepre"][0, :, :]
+            mask = ~np.isnan(qpepre)
+            if not np.any(mask):
+                os.remove(cropped_path)
+                raise ValueError("No valid (non-NaN) data found in qpepre variable.")
+
+            coords = np.argwhere(mask)
+            min_row, min_col = coords.min(axis=0)
+            max_row, max_col = coords.max(axis=0)
+
+            dst.createDimension("south_north", max_row - min_row + 1)
+            dst.createDimension("west_east", max_col - min_col + 1)
+            for name, dim in src.dimensions.items():
+                if name not in ["south_north", "west_east"]:
+                    dst.createDimension(name, len(dim))
+
+            for attr in src.ncattrs():
+                dst.setncattr(attr, src.getncattr(attr))
+
+            for name, var in src.variables.items():
+                out_var = dst.createVariable(name, var.datatype, var.dimensions)
+                for attr in var.ncattrs():
+                    out_var.setncattr(attr, var.getncattr(attr))
+
+                if var.ndim >= 2 and var.dimensions[-2:] == (
+                    "south_north",
+                    "west_east",
+                ):
+                    out_var[:] = var[..., min_row : max_row + 1, min_col : max_col + 1]
+                else:
+                    out_var[:] = var[:]
+
+        return cropped_path
+
+    def _process(self, date_str: str, hr_str: str):
+        """Processes a single date and hour by converting the corresponding QPEPRE text file to NetCDF, combining it with the matching RWRF NetCDF file, and cropping the result to the valid QPEPRE data region.
+
+        Parameters
+        ----------
+        date_str : str
+            The date string in 'YYYY/MM/DD' format.
+        hr_str : str
+            The hour string in 'HH' format (e.g., '00', '12', '23').
+        """
+        temp_nc_path = None
+        try:
+            t0 = time.perf_counter()
+            logger.info(f"converting txt to nc for {date_str} {hr_str}...")
+            temp_nc_path = self._convert_txt_to_nc(date_str, hr_str)
+            t1 = time.perf_counter()
+            self.time_records["txt_to_nc"] += (t1 - t0)
+            logger.info(f"conversion for {date_str} {hr_str} done: {temp_nc_path}")
+
+            t9 = time.perf_counter()
+            org_rwrf_path, new_rwrf_path = self._get_rwrf_paths(date_str, hr_str)
+            logger.info(f"RWRF path: {org_rwrf_path}, new path: {new_rwrf_path}")
+            pathlib.Path(new_rwrf_path).parent.mkdir(parents=True, exist_ok=True)
+
+
+            t2 = time.perf_counter()
+            logger.info(f"combining rwrf and qpepre for {date_str} {hr_str}...")
+            with Dataset(temp_nc_path) as qpepre_ds, Dataset(org_rwrf_path) as rwrf_ds:
+                self.combine_rwrf_qpepre(rwrf_ds, qpepre_ds, new_rwrf_path)
+            t3 = time.perf_counter()
+            self.time_records["combine"] += (t3 - t2)
+            logger.info(f"combining done rwrf and qpepre for {date_str} {hr_str}") 
+            
+            t4 = time.perf_counter()
+            logger.info(f"cropping rwrf by qpepre for {date_str} {hr_str}...")
+            cropped_path = self._crop_rwrf_by_qpepre(new_rwrf_path)
+            logger.info(f"Successfully created: {cropped_path}")
+            t5 = time.perf_counter()
+            self.time_records["crop"] += (t5 - t4)
+            logger.info(f"cropping rwrf done by qpepre for {date_str} {hr_str}...")
+
+        except Exception as e:
+            logger.debug(f"ERROR processing QPEPRE {date_str} {hr_str}- {e}")
+        finally:
+            if temp_nc_path and os.path.exists(temp_nc_path):
+                logger.debug(f"Removed temporary file: {temp_nc_path}")
+                os.remove(temp_nc_path)
+
+    def save_time_records(self, file_path: str, fmt: str = "csv") -> None:
+        """
+        Save accumulated time records to a specified file.
+
+        Parameters
+        ----------
+        file_path : str
+            Path to the file where timing results will be written.
+        fmt : str, optional
+            Format of output: "csv" or "json". Default is "csv".
+        """
+        out_path = pathlib.Path(file_path)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+
+        logger.info("Timing results:")
+        if fmt == "csv":
+            with out_path.open("w", newline="") as f:
+                w = csv.writer(f)
+                w.writerow(["step", "seconds"])
+                for step, seconds in self.time_records.items():
+                    w.writerow([step, f"{seconds:.6f}"])
+        elif fmt == "json":
+            with out_path.open("w", encoding="utf-8") as f:
+                json.dump(self.time_records, f, indent=2)
+        else:
+            raise ValueError("Unsupported format. Use 'csv' or 'json'.")
+
+        logger.info(f"Saved timing results to {out_path}")
+        


### PR DESCRIPTION
# PhysicsNeMo Pull Request

## Description
This PR introduces a multiprocessing pipeline for converting RWRF+QPEPRE NetCDF to NPZ and adds a parallel NPZ integrity/missing-file checker. It also standardizes logging and fixes `lexicon` imports when located one directory up.

### Highlights
- **Parallel wrapper & pipeline**
  - `dev/rwrf_process/des_process_rwrf_qpe/rwrf_nc_2_npz_wrapper.py`  
    CLI wrapper (no CONFIG imports) with `--workers`, explicit paths, and run metadata JSON.
  - `dev/rwrf_process/des_process_rwrf_qpe/rwrf_lite_mp.py`  
    Orchestrates (date, hour) jobs via `ProcessPoolExecutor`. Skips reprocessing if NPZ exists (unless `--overwrite`).
  - `dev/rwrf_process/des_process_rwrf_qpe/rwrf_qpepre_processor_mp.py`  
    QPEPRE TXT→NC, merge into RWRF, crop to valid area, stage timing, one-time RWRF index build.
  - `dev/rwrf_process/des_process_rwrf_qpe/rwrf_mp.py`  
    NetCDF→per-variable NPZ; resolves `lexicon` via adjusted `sys.path`.

- **Parallel NPZ checker**
  - `dev/rwrf_process/des_process_rwrf_qpe/check_rwrf_npz_missing.py`  
    Scans `{var}_{YYYYMMDD}{HH}.npz` across date/hour ranges using `ProcessPoolExecutor`. Optional strict open (`np.load`) flags unreadable files. CSV export supported.

- **Run helpers**
  - `dev/rwrf_process/des_process_rwrf_qpe/rwrf_nc_2_npz.sh` – example invocation.
  - `dev/rwrf_process/des_process_rwrf_qpe/check_rwrf_npz_missing.sh` – full-day (00–23) check.

- **Misc**
  - `dev/rwrf_process/des_process_rwrf_qpe/__init__.py` – mark package.

### Performance evaluation
<img width="617" height="86" alt="Screenshot 2025-09-03 at 5 16 02 PM" src="https://github.com/user-attachments/assets/62976c51-4e80-4928-a3b1-b904b3354061" />
Rrocessed 2 years (2019/08-2021/08) of rwrf data into 75 variables using 30 minutes.

### Key Design Notes
- **No CONFIG imports:** all paths/options via CLI.
- **Filename patterns:**
  - NetCDF: `wrfout_d01_{YYYY}-{MM}-{DD}_{HH}_interp[_cropped_qpepre].nc`
  - NPZ: `{variable}_{YYYYMMDD}{HH}.npz`
- **RWRF index:** built once; keyed by folder `YYYY-MM-DD_HH`.
- **Logging:** common logger name `"rwrf"` across modules; wrapper configures handlers/levels. Timing CSV emitted by processor.
- **Safety:** skip existing NPZs unless `--overwrite`; task-level exceptions are logged without halting the whole run.

## How to Run

### Convert RWRF+QPEPRE → NPZ (parallel)
```bash
python3 dev/rwrf_process/des_process_rwrf_qpe/rwrf_nc_2_npz_wrapper.py \
  --rwrf-src /path/to/RWRF \
  --qpepre-src /path/to/obs_1hrRain \
  --qpepre-nc-src /path/to/work_qpepre_nc \
  --npz-folder /path/to/npz/rwrf \
  --start-date 2019/08/01 \
  --end-date   2019/08/02 \
  --hours 00,01,02,03,04,05,06,07,08,09,10,11,12,13,14,15,16,17,18,19,20,21,22,23 \
  --workers 64 \
  --overwrite
```

### Check for Missing/Unreadable NPZ (parallel)
```bash
python3 dev/rwrf_process/des_process_rwrf_qpe/check_rwrf_npz_missing.py \
  --root /path/to/npz/rwrf \
  --start-date 2019/08/01 \
  --end-date   2019/08/02 \
  --hours 00,01,02,03,04,05,06,07,08,09,10,11,12,13,14,15,16,17,18,19,20,21,22,23 \
  --workers 64 \
  --strict \
  --csv-out missing.csv \
  --csv-unreadable-out unreadable.csv
```