### PR TITLE
Fix: remove underscore before hour in NPZ filenames

### DIFF
--- a/dev/rwrf_process/era5_nc_2_npz.py
+++ b/dev/rwrf_process/era5_nc_2_npz.py
@@ -134,7 +134,7 @@ class ERA5Processor:
     def process_single_time(self, date: datetime, hour: int, variable: str) -> bool:
         """Process a single time step and save as numpy array"""
 
-        filename = f"{variable}_{date.strftime('%Y%m%d')}_{hour:02d}.npz"
+        filename = f"{variable}_{date.strftime('%Y%m%d')}{hour:02d}.npz"
         output_path = self.output_base_path / filename
 
         logger.info("START: var=%s date=%s hour=%02d", variable, date.strftime("%Y-%m-%d"), hour)


### PR DESCRIPTION
# PhysicsNeMo Pull Request

## Description
This PR updates the NPZ filename generation logic in `era5_nc_2_npz.py` by removing the underscore (`_`) between the date and the hour.

### Before
```text
mslp_20190803_06.npz
t2m_20190804_12.npz
```

### After
```text
mslp_2019080306.npz
t2m_2019080412.npz
```

This change aligns NPZ file naming with the expected convention used by downstream StormCast preprocessing scripts and avoids mismatches when scanning files.

