### PR TITLE
# npz→zarr builder: fast multiprocessing, nearest-time substitution, and invariant export

### DIFF
--- a/dev/rwrf_process/des_era5_nc_2_npz/era5_nc_2_npz.py
+++ b/dev/rwrf_process/des_era5_nc_2_npz/era5_nc_2_npz.py
@@ -1,4 +1,3 @@
-from utils.config import CONFIG
 from netCDF4 import Dataset
 from datetime import datetime, timedelta
 import os
@@ -276,8 +275,7 @@ def main():
     )
     parser.add_argument(
         "--input-dir",
-        default=str(CONFIG.era5),
-        help="Input ERA5 base directory (default: CONFIG.era5)"
+        help="Input ERA5 base directory "
     )
     parser.add_argument(
         "--output-dir", 

--- a/dev/rwrf_process/des_era5_nc_2_npz/era5_nc_2_npz.sh
+++ b/dev/rwrf_process/des_era5_nc_2_npz/era5_nc_2_npz.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 python3 era5_nc_2_npz.py \
-    --input-dir path_to_era5_nc \
-    --output-dir path_to_store_era5_npz \
+    --input-dir /workspace/NCDR_StormCast/des/era5_rwrf_nc/era5 \
+    --output-dir /workspace/NCDR_StormCast/des/npz/era5 \
     --start-date 2019/08/01 \
     --end-date 2021/08/31 \
     --variable mslp sp t2m u10 v10 tp tcwv \

--- a/dev/rwrf_process/des_npz_2_zarr/inspect_zarr.py
+++ b/dev/rwrf_process/des_npz_2_zarr/inspect_zarr.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+zarr_inspect.py
+
+Inspect a StormCast Zarr dataset and log per-time, per-channel stats.
+
+- Supports Zarr written by build_stormcast_zarr_mp.py (variables "HighRes" or "LowRes")
+- Computes nan-aware stats: min, max, mean, std
+- Logs to file (and stdout) with progress messages
+- Optional CSV export
+
+Usage:
+  python zarr_inspect.py /path/to/HighRes/exp_train.zarr --var HighRes --log zarr_stats.log --csv stats.csv
+  python zarr_inspect.py /path/to/LowRes/exp_train.zarr  --var LowRes  --log zarr_stats.log
+"""
+
+import argparse
+import logging
+import os
+from pathlib import Path
+from typing import Optional, List
+
+import numpy as np
+import xarray as xr
+try:
+    import pandas as pd
+    HAS_PANDAS = True
+except Exception:
+    HAS_PANDAS = False
+
+
+LOG = logging.getLogger("zarr_inspect")
+
+
+def setup_logging(log_path: Optional[str], level: str = "INFO"):
+    handlers: List[logging.Handler] = [logging.StreamHandler()]
+    if log_path:
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        handlers.append(logging.FileHandler(log_path, mode="w", encoding="utf-8"))
+
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        handlers=handlers,
+    )
+    LOG.debug("Logger initialized (level=%s, file=%s)", level, log_path)
+
+
+def auto_var_name(ds: xr.Dataset, user_var: Optional[str]) -> str:
+    """Pick the data variable to inspect."""
+    if user_var:
+        if user_var not in ds.data_vars:
+            raise ValueError(f"--var {user_var!r} not in dataset data_vars {list(ds.data_vars)}")
+        return user_var
+    # If only one data var, use it
+    if len(ds.data_vars) == 1:
+        return list(ds.data_vars)[0]
+    # Prefer common names
+    for name in ("HighRes", "LowRes", "HighRes_invariants"):
+        if name in ds.data_vars:
+            return name
+    raise ValueError(f"Multiple data_vars found; please choose with --var from {list(ds.data_vars)}")
+
+
+def compute_stats(arr: np.ndarray):
+    """Return (nanmin, nanmax, nanmean, nanstd) for a numeric array."""
+    # Flatten to avoid axis issues; keep NaN-safe ops
+    return (
+        float(np.nanmin(arr)),
+        float(np.nanmax(arr)),
+        float(np.nanmean(arr)),
+        float(np.nanstd(arr)),
+    )
+
+
+def inspect_zarr(zarr_path: str, var_name: Optional[str], csv_out: Optional[str], only_first_n_hours: Optional[int]):
+    if not os.path.isdir(zarr_path):
+        raise FileNotFoundError(f"Zarr directory not found: {zarr_path}")
+
+    LOG.info("Opening Zarr: %s", zarr_path)
+    # Use consolidated metadata (your writer consolidates it)
+    ds = xr.open_zarr(zarr_path, consolidated=True)
+
+    # Pick variable
+    vname = auto_var_name(ds, var_name)
+    da = ds[vname]
+    LOG.info("Using variable: %s", vname)
+
+    # Basic coords sanity
+    time = da.coords.get("time", None)
+    channel = da.coords.get("channel", None)
+    y = da.coords.get("y", None)
+    x = da.coords.get("x", None)
+
+    LOG.info("Dims: %s | shape=%s", da.dims, tuple(da.shape))
+    if channel is not None:
+        LOG.info("Channels (%d): %s", channel.size, list(map(str, channel.values)))
+    if time is not None:
+        LOG.info("Time range: %s → %s (len=%d)", str(time.values[0]), str(time.values[-1]), time.size)
+    if y is not None and x is not None:
+        LOG.info("Spatial grid: y=%d, x=%d", y.size, x.size)
+
+    # Determine how many hours to scan
+    T = int(da.sizes.get("time", 1))
+    C = int(da.sizes.get("channel", 1))
+    scan_T = min(T, only_first_n_hours) if (only_first_n_hours and T) else T
+    LOG.info("Scanning %d hour(s) across %d channel(s)", scan_T, C)
+
+    # Optional CSV rows
+    rows = []
+
+    # Iterate hour by hour to keep memory bounded
+    for ti in range(scan_T):
+        # Select one time slice: shape (channel, y, x)
+        if "time" in da.dims:
+            slice_t = da.isel(time=ti)
+            t_val = str(slice_t.coords["time"].values)
+        else:
+            slice_t = da
+            t_val = "NA"
+
+        # Compute per-channel stats
+        for ci in range(C):
+            if "channel" in slice_t.dims:
+                slice_tc = slice_t.isel(channel=ci).to_numpy()  # (y, x)
+                c_name = str(slice_t.coords["channel"].values[ci])
+            else:
+                # Invariant or single-channel dataset
+                slice_tc = slice_t.to_numpy()
+                c_name = "0"
+
+            try:
+                vmin, vmax, vmean, vstd = compute_stats(slice_tc)
+                LOG.info(
+                    "[time=%s | ch=%s] min=%.6g max=%.6g mean=%.6g std=%.6g",
+                    t_val, c_name, vmin, vmax, vmean, vstd
+                )
+                if csv_out:
+                    rows.append({
+                        "time": t_val,
+                        "channel": c_name,
+                        "min": vmin,
+                        "max": vmax,
+                        "mean": vmean,
+                        "std": vstd,
+                    })
+            except ValueError:
+                # All-NaN slice
+                LOG.info("[time=%s | ch=%s] ALL NaNs", t_val, c_name)
+                if csv_out:
+                    rows.append({
+                        "time": t_val,
+                        "channel": c_name,
+                        "min": np.nan,
+                        "max": np.nan,
+                        "mean": np.nan,
+                        "std": np.nan,
+                    })
+
+        if (ti + 1) % 24 == 0 or (ti + 1) == scan_T:
+            LOG.info("Progress: %d/%d hour(s) processed", ti + 1, scan_T)
+
+    # Optional CSV
+    if csv_out:
+        if not HAS_PANDAS:
+            LOG.warning("pandas is not installed; cannot write CSV. Install pandas or omit --csv")
+        else:
+            Path(csv_out).parent.mkdir(parents=True, exist_ok=True)
+            import pandas as pd
+            pd.DataFrame(rows).to_csv(csv_out, index=False)
+            LOG.info("Wrote CSV summary to %s", csv_out)
+
+    # Global stats (all time, per channel) — optional extra
+    if "time" in da.dims and "channel" in da.dims:
+        LOG.info("Computing global per-channel stats across ALL %d hour(s) ...", T)
+        # Reduce along time, y, x; keep channel
+        # We’ll loop channels to avoid loading everything into RAM
+        for ci in range(C):
+            c_name = str(da.coords["channel"].values[ci])
+            sl = da.isel(channel=ci)
+            arr = sl.to_numpy()  # shape: (time, y, x) or (y, x) if no time
+            try:
+                vmin, vmax, vmean, vstd = compute_stats(arr)
+                LOG.info("[GLOBAL | ch=%s] min=%.6g max=%.6g mean=%.6g std=%.6g",
+                         c_name, vmin, vmax, vmean, vstd)
+            except ValueError:
+                LOG.info("[GLOBAL | ch=%s] ALL NaNs", c_name)
+
+    LOG.info("Done.")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Inspect a StormCast Zarr file and log per-time, per-channel stats.")
+    ap.add_argument("zarr_path", help="Path to the Zarr store directory (e.g., .../HighRes/exp_train.zarr)")
+    ap.add_argument("--var", default=None, help="Data variable to inspect (e.g., HighRes or LowRes). If omitted, auto-select.")
+    ap.add_argument("--log", default="zarr_inspect.log", help="Log file path (default: zarr_inspect.log)")
+    ap.add_argument("--log-level", default="DEBUG", choices=["DEBUG","INFO","WARNING","ERROR"])
+    ap.add_argument("--csv", default=None, help="Optional CSV path to save per-time, per-channel stats")
+    ap.add_argument("--first-n-hours", type=int, default=None, help="Limit to first N hours to scan (for quick checks)")
+    args = ap.parse_args()
+
+    setup_logging(args.log, args.log_level)
+
+    try:
+        inspect_zarr(args.zarr_path, args.var, args.csv, args.first_n_hours)
+    except Exception as e:
+        LOG.exception("Inspection failed: %s", e)
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/rwrf_process/des_npz_2_zarr/inspect_zarr.sh
+++ b/dev/rwrf_process/des_npz_2_zarr/inspect_zarr.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+python3 inspect_zarr.py /workspace/NCDR_StormCast/des/zarr/LowRes/stormcast_test_train.zarr \
+    --log mslp_20190806_zarr_inspect.log

--- a/dev/rwrf_process/des_npz_2_zarr/npz_2_zarr.py
+++ b/dev/rwrf_process/des_npz_2_zarr/npz_2_zarr.py
@@ -6,16 +6,15 @@
 # configurable CLI args. Supports two splits (train/valid) with one or multiple
 # date ranges each, and uses multiprocessing to speed up per-timestamp loading.
 #
-# NEW: When a file is missing at a target timestamp, we now substitute the
-#      NEAREST-IN-TIME available file for that *same variable* (±1h, ±2h, ...).
-#      If no file exists for that variable anywhere in the split, we fall back
-#      to zeros with the correct shape (from --var-dummy template).
+# Missing files are substituted with the NEAREST-IN-TIME available *raw NPZ file*
+# (scanned once from the cache folder). If a var has no files anywhere, we fall
+# back to zeros with the correct shape (from --var-dummy template).
 #
 # Example:
 #   python build_stormcast_zarr_mp.py \
 #     --cache-highres ../data/cache/rwrf/train \
 #     --cache-lowres  ../data/cache/era5/train \
-#     --data-base ../data \
+#     --zarr-base ../data \
 #     --experiment-name stormcast_small \
 #     --train-ranges "2019/08/01:2019/08/31" \
 #     --valid-ranges "2019/09/01:2019/09/07" \
@@ -23,14 +22,10 @@
 #     --domain-size 256,256 \
 #     --split both --workers 16 --log-level INFO
 #
-# Notes:
-# - If you omit --var-lowres / --var-highres / --invariants, built-in defaults are used.
-# - Invariants are taken from the HighRes cache (first timestamp in the split where all exist).
-# - Missing NPZs are replaced by the nearest-in-time available sample for that var; only if no
-#   samples exist at all do we fall back to zeros (dummy template).
 
 import argparse
 import os
+import re
 import time
 import logging
 import multiprocessing
@@ -49,23 +44,8 @@ import util_extract as u1
 
 LOG = logging.getLogger("npz2zarr")
 
-# -------------------- Logging -------------------- #
-def setup_logging(level: str, log_file: Optional[str]) -> None:
-    handlers: List[logging.Handler] = [logging.StreamHandler()]
-    if log_file:
-        handlers.append(logging.FileHandler(log_file, mode="a", encoding="utf-8"))
-
-    logging.basicConfig(
-        level=getattr(logging, level.upper(), logging.INFO),
-        format="%(asctime)s %(levelname)s %(name)s:%(lineno)d: %(message)s",
-        handlers=handlers,
-    )
-    LOG.debug("Logger initialized (level=%s, file=%s)", level, log_file)
-
-setup_logging("DEBUG", "/workspace/phy")
 # -------------------- Defaults -------------------- #
 DEFAULT_LOWRES_VARS = [
-    # Provided low-res (ERA5-like) channel list
     "mslp", "sp", "t2m", "u10", "v10", "tp", "tcwv",
     "q1000", "q850", "q500", "q250",
     "t1000", "t850", "t500", "t250",
@@ -75,7 +55,6 @@ DEFAULT_LOWRES_VARS = [
 ]
 
 DEFAULT_HIGHRES_VARS = [
-    # Provided high-res (RWRF) channel list
     "u10","v10","t2m","sp","msl","tcwv",
     "u50","u100","u150","u200","u250","u300","u400","u500","u600","u700","u850","u925","u1000",
     "v50","v100","v150","v200","v250","v300","v400","v500","v600","v700","v850","v925","v1000",
@@ -127,10 +106,6 @@ def make_hourly_datetimes(start_slash: str, end_slash: str) -> np.ndarray:
     return arr
 
 def parse_ranges(ranges: str) -> List[Tuple[str, str]]:
-    """
-    ranges string like: "YYYY/MM/DD:YYYY/MM/DD,YYYY/MM/DD:YYYY/MM/DD"
-    returns list of (start, end)
-    """
     out: List[Tuple[str, str]] = []
     for chunk in ranges.split(","):
         chunk = chunk.strip()
@@ -151,10 +126,43 @@ def concat_hourly(ranges: List[Tuple[str, str]]) -> np.ndarray:
     LOG.info("Constructed datetime grid from %d range(s): total %d hours", len(ranges), len(out))
     return out
 
-# -------------------- Data helpers -------------------- #
+# -------------------- Filenames & data helpers -------------------- #
 def npz_path_for(cache_dir: str, var: str, dt: np.datetime64) -> str:
     yy, mm, dd, hh = np.datetime_as_string(dt, unit="h").replace("T", "-").split("-")
     return os.path.join(cache_dir, f"{var}_{yy}{mm}{dd}{hh}.npz")
+
+# Single regex to parse BOTH var and timestamp from filenames
+_RX_VAR_TS = re.compile(r"^(?P<var>.+)_(?P<ts>\d{10})\.npz$")  # var_YYYYMMDDHH.npz
+
+def scan_cache_index(cache_dir: str) -> Dict[str, np.ndarray]:
+    """
+    Scan the cache directory ONCE and build an index:
+        { var_name -> sorted unique numpy array of datetime64[h] where files exist }
+    Much faster than calling os.listdir() per variable.
+    """
+    index: Dict[str, List[np.datetime64]] = {}
+    try:
+        # scandir is faster than listdir + isfile
+        for entry in os.scandir(cache_dir):
+            if not entry.is_file():
+                continue
+            name = entry.name
+            m = _RX_VAR_TS.match(name)
+            if not m:
+                continue
+            var = m.group("var")
+            stamp = m.group("ts")  # YYYYMMDDHH
+            dt = np.datetime64(f"{stamp[:4]}-{stamp[4:6]}-{stamp[6:8]}T{stamp[8:10]}:00").astype("datetime64[h]")
+            index.setdefault(var, []).append(dt)
+    except FileNotFoundError:
+        pass
+
+    out: Dict[str, np.ndarray] = {}
+    for var, lst in index.items():
+        arr = np.sort(np.unique(np.array(lst, dtype="datetime64[h]")))
+        out[var] = arr
+    LOG.info("Cache scan complete: %d vars indexed in '%s'", len(out), cache_dir)
+    return out
 
 def try_build_dummy(
     datetime_array: np.ndarray,
@@ -163,104 +171,100 @@ def try_build_dummy(
     lon_min: float, lon_max: float,
     lat_min: float, lat_max: float,
     domain_size: Tuple[int, int],
+    cache_index: Optional[Dict[str, np.ndarray]] = None,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """
-    Find the first timestamp where dummy_var NPZ exists and use it to infer shape.
-    Returns: (dummy_data, lon_grid, lat_grid, times)
+    Find a dummy template from the first existing file of dummy_var among the
+    requested grid or, if none, from any file present for that var in the index.
     """
-    LOG.info("Searching for dummy template var='%s' in %d timestamps under %s",
-             dummy_var, len(datetime_array), cache_dir)
+    LOG.info("Searching for dummy template var='%s' under %s", dummy_var, cache_dir)
+    # Prefer an exact grid timestamp
     for dt in list(datetime_array):
         candidate = npz_path_for(cache_dir, dummy_var, dt)
         if os.path.exists(candidate):
             LOG.info("Using %s as dummy template", candidate)
             real_arr, lon_grid, lat_grid, times = u1.extract_region(
-                candidate, dummy_var, lon_min, lon_max, lat_min, lat_max,
-                domain_size=domain_size,
+                candidate, dummy_var, lon_min, lon_max, lat_min, lat_max, domain_size=domain_size
             )
             Ny_full, Nx_full = lat_grid.shape
             Ny_tgt, Nx_tgt = domain_size
             if Ny_full < Ny_tgt or Nx_full < Nx_tgt:
-                LOG.debug("Template smaller than target; interpolating to %s", domain_size)
                 real_arr, lon_grid, lat_grid = u1.interp_to_domain(
                     lon_grid, lat_grid, real_arr, domain_size, method="linear"
                 )
-            dummy_arr = np.full_like(real_arr, fill_value=0.0)
-            LOG.debug("Dummy template shape=%s", tuple(dummy_arr.shape))
-            return dummy_arr, lon_grid, lat_grid, times
+            return np.full_like(real_arr, 0.0), lon_grid, lat_grid, times
+
+    # Else: any file for dummy_var from the prebuilt index
+    if cache_index is None:
+        cache_index = scan_cache_index(cache_dir)
+    avail_any = cache_index.get(dummy_var, np.array([], dtype="datetime64[h]"))
+    if avail_any.size:
+        dt = avail_any[0]
+        candidate = npz_path_for(cache_dir, dummy_var, dt)
+        LOG.info("Using %s as dummy template (first available in cache index)", candidate)
+        real_arr, lon_grid, lat_grid, times = u1.extract_region(
+            candidate, dummy_var, lon_min, lon_max, lat_min, lat_max, domain_size=domain_size
+        )
+        Ny_full, Nx_full = lat_grid.shape
+        Ny_tgt, Nx_tgt = domain_size
+        if Ny_full < Ny_tgt or Nx_full < Nx_tgt:
+            real_arr, lon_grid, lat_grid = u1.interp_to_domain(
+                lon_grid, lat_grid, real_arr, domain_size, method="linear"
+            )
+        return np.full_like(real_arr, 0.0), lon_grid, lat_grid, times
+
     raise FileNotFoundError(
-        "Could not build dummy: no NPZ found for --var-dummy across the provided datetimes."
+        "Could not build dummy: no NPZ found for --var-dummy in grid or cache folder."
     )
 
 # --------- Nearest-available substitution helpers ---------- #
-def build_availability_map(cache_dir: str, var_list: List[str], dts: np.ndarray) -> Dict[str, np.ndarray]:
+def nearest_dt(target_dt: np.datetime64, sorted_dts: np.ndarray) -> Optional[np.datetime64]:
     """
-    For each variable, return a sorted array of indices (into dts) where a file exists.
+    Return the datetime64[h] in sorted_dts nearest to target_dt.
+    Tie → earlier one. None if sorted_dts is empty.
     """
-    avail: Dict[str, List[int]] = {v: [] for v in var_list}
-    for i, dt in enumerate(dts):
-        for v in var_list:
-            if os.path.exists(npz_path_for(cache_dir, v, dt)):
-                avail[v].append(i)
-    return {v: np.array(ixs, dtype=int) for v, ixs in avail.items()}
-
-def nearest_index(target_idx: int, sorted_indices: np.ndarray) -> Optional[int]:
-    """
-    Given a sorted array of available indices, return the index (into that array)
-    of the nearest available element to target_idx, breaking ties by choosing the earlier one.
-    Returns None if sorted_indices is empty.
-    """
-    if sorted_indices.size == 0:
+    if sorted_dts.size == 0:
         return None
-    pos = np.searchsorted(sorted_indices, target_idx)
-    if pos == 0:
-        return sorted_indices[0]
-    if pos == sorted_indices.size:
-        return sorted_indices[-1]
-    before = sorted_indices[pos - 1]
-    after  = sorted_indices[pos]
-    # tie-break: prefer 'before' if equal distance
-    return before if (target_idx - before) <= (after - target_idx) else after
+    diffs = np.abs(sorted_dts.astype("datetime64[h]") - target_dt.astype("datetime64[h]"))
+    imin = int(np.argmin(diffs))
+    best = sorted_dts[imin]
+    ties = np.where(diffs == diffs[imin])[0]
+    if ties.size > 1:
+        best = sorted_dts[int(np.min(ties))]
+    return best
 
-def load_or_nearest(
+def load_or_nearest_by_cache(
     cache_dir: str,
     var: str,
-    dt_idx: int,
-    all_datetimes: np.ndarray,
-    avail_indices_for_var: np.ndarray,
+    target_dt: np.datetime64,
+    avail_dts_for_var: np.ndarray,
     lon_min: float, lon_max: float,
     lat_min: float, lat_max: float,
     domain_size: Tuple[int, int],
     dummy_data: np.ndarray,
-) -> Tuple[np.ndarray, bool, Optional[int]]:
+) -> Tuple[np.ndarray, bool, Optional[np.datetime64]]:
     """
-    Try to load var at dt_idx; if missing, substitute the nearest-in-time available
-    timestamp for that var. Returns (data, was_substituted, src_idx_or_None).
-    If no sample exists for this var anywhere, returns (dummy, True, None).
+    Try loading var at target_dt; if missing, substitute nearest-in-time from cache index.
+    Returns (data, was_substituted, src_dt_or_None). If no sample exists, return (dummy, True, None).
     """
-    # 1) direct hit?
-    dt = all_datetimes[dt_idx]
-    path = npz_path_for(cache_dir, var, dt)
+    path = npz_path_for(cache_dir, var, target_dt)
     if os.path.exists(path):
         data, lon_grid, lat_grid, _ = u1.extract_region(
             path, var, lon_min, lon_max, lat_min, lat_max, domain_size=domain_size
         )
         data, lon_grid, lat_grid = u1.interp_to_domain(lon_grid, lat_grid, data, domain_size, method="linear")
-        return data, False, dt_idx
+        return data, False, target_dt
 
-    # 2) nearest substitution
-    near_idx = nearest_index(dt_idx, avail_indices_for_var)
-    if near_idx is None:
-        # no sample for this var at all -> zeros fallback
+    near_dt = nearest_dt(target_dt, avail_dts_for_var)
+    if near_dt is None:
         return dummy_data.copy(), True, None
 
-    dt2 = all_datetimes[near_idx]
-    path2 = npz_path_for(cache_dir, var, dt2)
+    path2 = npz_path_for(cache_dir, var, near_dt)
     data, lon_grid, lat_grid, _ = u1.extract_region(
         path2, var, lon_min, lon_max, lat_min, lat_max, domain_size=domain_size
     )
     data, lon_grid, lat_grid = u1.interp_to_domain(lon_grid, lat_grid, data, domain_size, method="linear")
-    return data, True, near_idx
+    return data, True, near_dt
 
 # -------------------- Multiprocessing worker -------------------- #
 def _load_timestamp_block(
@@ -268,7 +272,7 @@ def _load_timestamp_block(
     all_datetimes: np.ndarray,
     cache_dir: str,
     var_list: List[str],
-    avail_map: Dict[str, np.ndarray],   # var -> sorted indices where file exists
+    avail_map: Dict[str, np.ndarray],   # var -> sorted datetimes present in cache (preindexed)
     lon_min: float, lon_max: float,
     lat_min: float, lat_max: float,
     domain_size: Tuple[int, int],
@@ -276,22 +280,24 @@ def _load_timestamp_block(
 ) -> tuple:
     """
     Worker: Load all variables for one timestamp, using nearest-in-time substitution
-    if missing. Returns (index, stacked_array, substitutions_log).
+    from *cache-scanned* availability. Returns (index, stacked_array, substitutions_log).
     """
     channel_arr = None
     subs_msgs: List[str] = []
 
+    tgt_dt = all_datetimes[idx]
     for var in var_list:
-        data, substituted, src_idx = load_or_nearest(
-            cache_dir, var, idx, all_datetimes, avail_map[var],
+        LOG.info(f"loading timestamp block for {var} at {tgt_dt}")
+        data, substituted, src_dt = load_or_nearest_by_cache(
+            cache_dir, var, tgt_dt, avail_map.get(var, np.array([], dtype="datetime64[h]")),
             lon_min, lon_max, lat_min, lat_max, domain_size, dummy_data
         )
         if substituted:
-            tgt_str = np.datetime_as_string(all_datetimes[idx], unit="h")
-            if src_idx is None:
+            tgt_str = np.datetime_as_string(tgt_dt, unit="h")
+            if src_dt is None:
                 subs_msgs.append(f"{var} {tgt_str} <- ZERO (no samples for var)")
             else:
-                src_str = np.datetime_as_string(all_datetimes[src_idx], unit="h")
+                src_str = np.datetime_as_string(src_dt, unit="h")
                 subs_msgs.append(f"{var} {tgt_str} <- nearest {src_str}")
 
         channel_arr = data.copy() if channel_arr is None else np.concatenate((channel_arr, data), axis=0)
@@ -319,22 +325,28 @@ def build_split(
 ) -> None:
     """
     Assemble HighRes/LowRes 4D arrays over a datetime grid, compute stats, and
-    write Zarr stores. Also write invariants (from the first available timestamp
-    of the split) once under zarr_base/invariants/.
+    write Zarr stores. Also write invariants once under zarr_base/invariants/.
     """
     t_split0 = time.perf_counter()
     LOG.info("[%s] Building split with %d timestamps | HR vars=%d | LR vars=%d | workers=%d",
              split_name, len(datetime_array), len(vars_highres), len(vars_lowres), workers)
 
+    # ---- Pre-scan cache once per level ----
+    LOG.info("[%s] Scanning HighRes cache index ...", split_name)
+    hr_index = scan_cache_index(cache_highres)
+    LOG.info("[%s] Scanning LowRes cache index ...", split_name)
+    lr_index = scan_cache_index(cache_lowres)
+
     # ---- Dummy template from HighRes cache ----
     dummy_data, dummy_lon_grid, dummy_lat_grid, _ = try_build_dummy(
-        datetime_array, cache_highres, dummy_var, lon_min, lon_max, lat_min, lat_max, domain_size
+        datetime_array, cache_highres, dummy_var, lon_min, lon_max, lat_min, lat_max, domain_size, cache_index=hr_index
     )
 
-    def build_level(fname: str, cache_dir: str, var_list: List[str]):
+    def build_level(fname: str, cache_dir: str, var_list: List[str], cache_index: Dict[str, np.ndarray]):
         t0 = time.perf_counter()
-        LOG.info("[%s] %s: precomputing availability map ...", split_name, fname)
-        avail_map = build_availability_map(cache_dir, var_list, datetime_array)
+        LOG.info("[%s] %s: preparing availability map from cache index ...", split_name, fname)
+        # avail_map is just a filter to the global index for vars we actually need
+        avail_map: Dict[str, np.ndarray] = {v: cache_index.get(v, np.array([], dtype="datetime64[h]")) for v in var_list}
         missing_all = sum(1 for v in var_list if avail_map[v].size == 0)
         if missing_all:
             LOG.warning("[%s] %s: %d/%d vars have NO samples; will fall back to zeros.",
@@ -380,8 +392,8 @@ def build_split(
         LOG.info("[%s] %s: computing stats ...", split_name, fname)
         means = np.nanmean(data_arr, axis=(0, 2, 3)).astype(np.float32)
         stds  = np.nanstd (data_arr, axis=(0, 2, 3)).astype(np.float32)
-        np.save(stats_dir / f"{experiment_name}_{split_name}_means.npy", means)
-        np.save(stats_dir / f"{experiment_name}_{split_name}_stds.npy",  stds)
+        np.save(stats_dir / f"means.npy", means)
+        np.save(stats_dir / f"stds.npy",  stds)
         LOG.info("[%s] %s: saved stats under %s", split_name, fname, stats_dir)
 
         # Zarr write
@@ -408,11 +420,11 @@ def build_split(
         t1 = time.perf_counter()
         LOG.info("[%s] %s: total elapsed %.1fs", split_name, fname, t1 - t0)
 
-    # Build HighRes / LowRes
-    build_level("HighRes", cache_highres, vars_highres)
-    build_level("LowRes",  cache_lowres,  vars_lowres)
+    # Build HighRes / LowRes using the prebuilt indexes
+    build_level("HighRes", cache_highres, vars_highres, hr_index)
+    build_level("LowRes",  cache_lowres,  vars_lowres,  lr_index)
 
-    # Invariants
+    # Invariants (pulled from HighRes cache)
     LOG.info("[%s] Building invariants ...", split_name)
     inv_arr = None
     dt0 = None
@@ -430,6 +442,7 @@ def build_split(
     LOG.info("[%s] Using %s for invariants extraction", split_name, np.datetime_as_string(dt0, unit="h"))
 
     for var in invariants:
+        LOG.info(f"processing invariants for {var}")
         path = npz_path_for(cache_highres, var, dt0)
         dt_data, lon_grid, lat_grid, _ = u1.extract_region(
             path, var, lon_min, lon_max, lat_min, lat_max, domain_size=domain_size
@@ -465,7 +478,7 @@ def build_split(
 # -------------------- Main -------------------- #
 def main():
     ap = argparse.ArgumentParser(
-        description="Build HighRes/LowRes Zarr datasets for train/valid splits from NPZ caches (multiprocessing, nearest-time substitution)."
+        description="Build HighRes/LowRes Zarr datasets from NPZ caches (multiprocessing, nearest raw NPZ substitution; cached directory index)."
     )
     # Variables (optional; fall back to defaults if omitted)
     ap.add_argument("--var-lowres",  default=None,
@@ -522,7 +535,6 @@ def main():
     train_dt = concat_hourly(parse_ranges(args.train_ranges))
     valid_dt = concat_hourly(parse_ranges(args.valid_ranges))
 
-    # Run selected splits
     if args.split in ("train", "both"):
         LOG.info("=== Building TRAIN split ===")
         build_split(

--- a/dev/rwrf_process/des_npz_2_zarr/npz_2_zarr.py
+++ b/dev/rwrf_process/des_npz_2_zarr/npz_2_zarr.py
@@ -1,0 +1,567 @@
+#!/usr/bin/env python3
+#
+# build_stormcast_zarr_mp.py
+#
+# Build HighRes/LowRes Zarr datasets (and invariants) from NPZ caches using fully
+# configurable CLI args. Supports two splits (train/valid) with one or multiple
+# date ranges each, and uses multiprocessing to speed up per-timestamp loading.
+#
+# NEW: When a file is missing at a target timestamp, we now substitute the
+#      NEAREST-IN-TIME available file for that *same variable* (±1h, ±2h, ...).
+#      If no file exists for that variable anywhere in the split, we fall back
+#      to zeros with the correct shape (from --var-dummy template).
+#
+# Example:
+#   python build_stormcast_zarr_mp.py \
+#     --cache-highres ../data/cache/rwrf/train \
+#     --cache-lowres  ../data/cache/era5/train \
+#     --data-base ../data \
+#     --experiment-name stormcast_small \
+#     --train-ranges "2019/08/01:2019/08/31" \
+#     --valid-ranges "2019/09/01:2019/09/07" \
+#     --lon-min 118 --lon-max 123.5 --lat-min 21.5 --lat-max 26.8 \
+#     --domain-size 256,256 \
+#     --split both --workers 16 --log-level INFO
+#
+# Notes:
+# - If you omit --var-lowres / --var-highres / --invariants, built-in defaults are used.
+# - Invariants are taken from the HighRes cache (first timestamp in the split where all exist).
+# - Missing NPZs are replaced by the nearest-in-time available sample for that var; only if no
+#   samples exist at all do we fall back to zeros (dummy template).
+
+import argparse
+import os
+import time
+import logging
+import multiprocessing
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+from typing import List, Tuple, Optional, Dict
+
+import numpy as np
+import xarray as xr
+import zarr
+
+# You must provide these utilities in PYTHONPATH:
+#   util_extract.extract_region(npz_path, var, lon_min, lon_max, lat_min, lat_max, domain_size)
+#   util_extract.interp_to_domain(lon, lat, data, domain_size, method="linear")
+import util_extract as u1
+
+LOG = logging.getLogger("npz2zarr")
+
+# -------------------- Logging -------------------- #
+def setup_logging(level: str, log_file: Optional[str]) -> None:
+    handlers: List[logging.Handler] = [logging.StreamHandler()]
+    if log_file:
+        handlers.append(logging.FileHandler(log_file, mode="a", encoding="utf-8"))
+
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s:%(lineno)d: %(message)s",
+        handlers=handlers,
+    )
+    LOG.debug("Logger initialized (level=%s, file=%s)", level, log_file)
+
+setup_logging("DEBUG", "/workspace/phy")
+# -------------------- Defaults -------------------- #
+DEFAULT_LOWRES_VARS = [
+    # Provided low-res (ERA5-like) channel list
+    "mslp", "sp", "t2m", "u10", "v10", "tp", "tcwv",
+    "q1000", "q850", "q500", "q250",
+    "t1000", "t850", "t500", "t250",
+    "u1000", "u850", "u500", "u250",
+    "v1000", "v850", "v500", "v250",
+    "z1000", "z850", "z500", "z250",
+]
+
+DEFAULT_HIGHRES_VARS = [
+    # Provided high-res (RWRF) channel list
+    "u10","v10","t2m","sp","msl","tcwv",
+    "u50","u100","u150","u200","u250","u300","u400","u500","u600","u700","u850","u925","u1000",
+    "v50","v100","v150","v200","v250","v300","v400","v500","v600","v700","v850","v925","v1000",
+    "z50","z100","z150","z200","z250","z300","z400","z500","z600","z700","z850","z925","z1000",
+    "t50","t100","t150","t200","t250","t300","t400","t500","t600","t700","t850","t925","t1000",
+    "q50","q100","q150","q200","q250","q300","q400","q500","q600","q700","q850","q925","q1000",
+    "qpepre","lsm","orog",
+]
+
+DEFAULT_INVARIANTS = ["lsm", "orog"]
+DEFAULT_DUMMY_VAR = "t2m"
+
+# -------------------- Logging -------------------- #
+def setup_logging(level: str, log_file: Optional[str]) -> None:
+    handlers: List[logging.Handler] = [logging.StreamHandler()]
+    if log_file:
+        handlers.append(logging.FileHandler(log_file, mode="a", encoding="utf-8"))
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s:%(lineno)d: %(message)s",
+        handlers=handlers,
+    )
+    LOG.debug("Logger initialized (level=%s, file=%s)", level, log_file)
+
+# -------------------- CLI helpers -------------------- #
+def parse_csv(s: Optional[str]) -> Optional[List[str]]:
+    if s is None:
+        return None
+    vals = [p.strip() for p in s.split(",") if p.strip()]
+    LOG.debug("Parsed CSV '%s' -> %s", s, vals)
+    return vals
+
+def parse_domain_size(s: str) -> Tuple[int, int]:
+    parts = [p.strip() for p in s.split(",")]
+    if len(parts) != 2:
+        raise ValueError("--domain-size must be like H,W (e.g., 256,256)")
+    H = int(parts[0]); W = int(parts[1])
+    if H <= 0 or W <= 0:
+        raise ValueError("domain-size must be positive integers")
+    LOG.debug("Parsed domain size '%s' -> (%d, %d)", s, H, W)
+    return (H, W)
+
+def make_hourly_datetimes(start_slash: str, end_slash: str) -> np.ndarray:
+    base = np.datetime64(start_slash.replace("/", "-") + "T00:00:00")
+    end  = np.datetime64(end_slash.replace("/", "-")) + np.timedelta64(23, "h")
+    total_hours = int((end - base) / np.timedelta64(1, "h")) + 1
+    arr = base + np.arange(total_hours, dtype=np.int64) * np.timedelta64(1, "h")
+    LOG.debug("Hourly datetimes %s -> %s (count=%d)", start_slash, end_slash, len(arr))
+    return arr
+
+def parse_ranges(ranges: str) -> List[Tuple[str, str]]:
+    """
+    ranges string like: "YYYY/MM/DD:YYYY/MM/DD,YYYY/MM/DD:YYYY/MM/DD"
+    returns list of (start, end)
+    """
+    out: List[Tuple[str, str]] = []
+    for chunk in ranges.split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        if ":" not in chunk:
+            raise ValueError(f"Bad range '{chunk}', expected A:B")
+        a, b = [q.strip() for q in chunk.split(":", 1)]
+        out.append((a, b))
+    if not out:
+        raise ValueError("No date ranges parsed.")
+    LOG.debug("Parsed ranges '%s' -> %s", ranges, out)
+    return out
+
+def concat_hourly(ranges: List[Tuple[str, str]]) -> np.ndarray:
+    blocks = [make_hourly_datetimes(a, b) for a, b in ranges]
+    out = np.concatenate(blocks) if blocks else np.array([], dtype="datetime64[h]")
+    LOG.info("Constructed datetime grid from %d range(s): total %d hours", len(ranges), len(out))
+    return out
+
+# -------------------- Data helpers -------------------- #
+def npz_path_for(cache_dir: str, var: str, dt: np.datetime64) -> str:
+    yy, mm, dd, hh = np.datetime_as_string(dt, unit="h").replace("T", "-").split("-")
+    return os.path.join(cache_dir, f"{var}_{yy}{mm}{dd}{hh}.npz")
+
+def try_build_dummy(
+    datetime_array: np.ndarray,
+    cache_dir: str,
+    dummy_var: str,
+    lon_min: float, lon_max: float,
+    lat_min: float, lat_max: float,
+    domain_size: Tuple[int, int],
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Find the first timestamp where dummy_var NPZ exists and use it to infer shape.
+    Returns: (dummy_data, lon_grid, lat_grid, times)
+    """
+    LOG.info("Searching for dummy template var='%s' in %d timestamps under %s",
+             dummy_var, len(datetime_array), cache_dir)
+    for dt in list(datetime_array):
+        candidate = npz_path_for(cache_dir, dummy_var, dt)
+        if os.path.exists(candidate):
+            LOG.info("Using %s as dummy template", candidate)
+            real_arr, lon_grid, lat_grid, times = u1.extract_region(
+                candidate, dummy_var, lon_min, lon_max, lat_min, lat_max,
+                domain_size=domain_size,
+            )
+            Ny_full, Nx_full = lat_grid.shape
+            Ny_tgt, Nx_tgt = domain_size
+            if Ny_full < Ny_tgt or Nx_full < Nx_tgt:
+                LOG.debug("Template smaller than target; interpolating to %s", domain_size)
+                real_arr, lon_grid, lat_grid = u1.interp_to_domain(
+                    lon_grid, lat_grid, real_arr, domain_size, method="linear"
+                )
+            dummy_arr = np.full_like(real_arr, fill_value=0.0)
+            LOG.debug("Dummy template shape=%s", tuple(dummy_arr.shape))
+            return dummy_arr, lon_grid, lat_grid, times
+    raise FileNotFoundError(
+        "Could not build dummy: no NPZ found for --var-dummy across the provided datetimes."
+    )
+
+# --------- Nearest-available substitution helpers ---------- #
+def build_availability_map(cache_dir: str, var_list: List[str], dts: np.ndarray) -> Dict[str, np.ndarray]:
+    """
+    For each variable, return a sorted array of indices (into dts) where a file exists.
+    """
+    avail: Dict[str, List[int]] = {v: [] for v in var_list}
+    for i, dt in enumerate(dts):
+        for v in var_list:
+            if os.path.exists(npz_path_for(cache_dir, v, dt)):
+                avail[v].append(i)
+    return {v: np.array(ixs, dtype=int) for v, ixs in avail.items()}
+
+def nearest_index(target_idx: int, sorted_indices: np.ndarray) -> Optional[int]:
+    """
+    Given a sorted array of available indices, return the index (into that array)
+    of the nearest available element to target_idx, breaking ties by choosing the earlier one.
+    Returns None if sorted_indices is empty.
+    """
+    if sorted_indices.size == 0:
+        return None
+    pos = np.searchsorted(sorted_indices, target_idx)
+    if pos == 0:
+        return sorted_indices[0]
+    if pos == sorted_indices.size:
+        return sorted_indices[-1]
+    before = sorted_indices[pos - 1]
+    after  = sorted_indices[pos]
+    # tie-break: prefer 'before' if equal distance
+    return before if (target_idx - before) <= (after - target_idx) else after
+
+def load_or_nearest(
+    cache_dir: str,
+    var: str,
+    dt_idx: int,
+    all_datetimes: np.ndarray,
+    avail_indices_for_var: np.ndarray,
+    lon_min: float, lon_max: float,
+    lat_min: float, lat_max: float,
+    domain_size: Tuple[int, int],
+    dummy_data: np.ndarray,
+) -> Tuple[np.ndarray, bool, Optional[int]]:
+    """
+    Try to load var at dt_idx; if missing, substitute the nearest-in-time available
+    timestamp for that var. Returns (data, was_substituted, src_idx_or_None).
+    If no sample exists for this var anywhere, returns (dummy, True, None).
+    """
+    # 1) direct hit?
+    dt = all_datetimes[dt_idx]
+    path = npz_path_for(cache_dir, var, dt)
+    if os.path.exists(path):
+        data, lon_grid, lat_grid, _ = u1.extract_region(
+            path, var, lon_min, lon_max, lat_min, lat_max, domain_size=domain_size
+        )
+        data, lon_grid, lat_grid = u1.interp_to_domain(lon_grid, lat_grid, data, domain_size, method="linear")
+        return data, False, dt_idx
+
+    # 2) nearest substitution
+    near_idx = nearest_index(dt_idx, avail_indices_for_var)
+    if near_idx is None:
+        # no sample for this var at all -> zeros fallback
+        return dummy_data.copy(), True, None
+
+    dt2 = all_datetimes[near_idx]
+    path2 = npz_path_for(cache_dir, var, dt2)
+    data, lon_grid, lat_grid, _ = u1.extract_region(
+        path2, var, lon_min, lon_max, lat_min, lat_max, domain_size=domain_size
+    )
+    data, lon_grid, lat_grid = u1.interp_to_domain(lon_grid, lat_grid, data, domain_size, method="linear")
+    return data, True, near_idx
+
+# -------------------- Multiprocessing worker -------------------- #
+def _load_timestamp_block(
+    idx: int,
+    all_datetimes: np.ndarray,
+    cache_dir: str,
+    var_list: List[str],
+    avail_map: Dict[str, np.ndarray],   # var -> sorted indices where file exists
+    lon_min: float, lon_max: float,
+    lat_min: float, lat_max: float,
+    domain_size: Tuple[int, int],
+    dummy_data: np.ndarray,
+) -> tuple:
+    """
+    Worker: Load all variables for one timestamp, using nearest-in-time substitution
+    if missing. Returns (index, stacked_array, substitutions_log).
+    """
+    channel_arr = None
+    subs_msgs: List[str] = []
+
+    for var in var_list:
+        data, substituted, src_idx = load_or_nearest(
+            cache_dir, var, idx, all_datetimes, avail_map[var],
+            lon_min, lon_max, lat_min, lat_max, domain_size, dummy_data
+        )
+        if substituted:
+            tgt_str = np.datetime_as_string(all_datetimes[idx], unit="h")
+            if src_idx is None:
+                subs_msgs.append(f"{var} {tgt_str} <- ZERO (no samples for var)")
+            else:
+                src_str = np.datetime_as_string(all_datetimes[src_idx], unit="h")
+                subs_msgs.append(f"{var} {tgt_str} <- nearest {src_str}")
+
+        channel_arr = data.copy() if channel_arr is None else np.concatenate((channel_arr, data), axis=0)
+
+    if channel_arr.ndim != 3:
+        raise RuntimeError(f"Unexpected per-timestamp shape: {channel_arr.shape}")
+    return idx, channel_arr, subs_msgs
+
+# -------------------- Split builder (MP) -------------------- #
+def build_split(
+    split_name: str,
+    datetime_array: np.ndarray,
+    cache_highres: str,
+    cache_lowres: str,
+    vars_highres: List[str],
+    vars_lowres: List[str],
+    dummy_var: str,
+    invariants: List[str],
+    lon_min: float, lon_max: float,
+    lat_min: float, lat_max: float,
+    domain_size: Tuple[int, int],
+    zarr_base: str,
+    experiment_name: str,
+    workers: int,
+) -> None:
+    """
+    Assemble HighRes/LowRes 4D arrays over a datetime grid, compute stats, and
+    write Zarr stores. Also write invariants (from the first available timestamp
+    of the split) once under zarr_base/invariants/.
+    """
+    t_split0 = time.perf_counter()
+    LOG.info("[%s] Building split with %d timestamps | HR vars=%d | LR vars=%d | workers=%d",
+             split_name, len(datetime_array), len(vars_highres), len(vars_lowres), workers)
+
+    # ---- Dummy template from HighRes cache ----
+    dummy_data, dummy_lon_grid, dummy_lat_grid, _ = try_build_dummy(
+        datetime_array, cache_highres, dummy_var, lon_min, lon_max, lat_min, lat_max, domain_size
+    )
+
+    def build_level(fname: str, cache_dir: str, var_list: List[str]):
+        t0 = time.perf_counter()
+        LOG.info("[%s] %s: precomputing availability map ...", split_name, fname)
+        avail_map = build_availability_map(cache_dir, var_list, datetime_array)
+        missing_all = sum(1 for v in var_list if avail_map[v].size == 0)
+        if missing_all:
+            LOG.warning("[%s] %s: %d/%d vars have NO samples; will fall back to zeros.",
+                        split_name, fname, missing_all, len(var_list))
+
+        LOG.info("[%s] %s: assembling with multiprocessing (vars=%d, workers=%d)",
+                 split_name, fname, len(var_list), workers)
+
+        stats_dir = Path(zarr_base) / fname / "stats"
+        stats_dir.mkdir(parents=True, exist_ok=True)
+
+        T = len(datetime_array)
+        C = len(var_list)
+        H, W = domain_size
+
+        # Preallocate final array
+        data_arr = np.empty((T, C, H, W), dtype=np.float32)
+        subs_log: List[str] = []
+
+        # Fan out
+        with ProcessPoolExecutor(max_workers=workers) as ex:
+            futures = [
+                ex.submit(
+                    _load_timestamp_block,
+                    idx, datetime_array, cache_dir, var_list, avail_map,
+                    lon_min, lon_max, lat_min, lat_max, domain_size, dummy_data
+                )
+                for idx in range(T)
+            ]
+
+            for i, fut in enumerate(as_completed(futures), 1):
+                idx, block, subs = fut.result()
+                data_arr[idx] = block
+                if subs:
+                    subs_log.extend(subs)
+                if i % 500 == 0 or i == T:
+                    LOG.info("[%s] %s: collected %d/%d", split_name, fname, i, T)
+
+        LOG.info("[%s] %s: stacked array shape=%s | substitutions applied=%d",
+                 split_name, fname, tuple(data_arr.shape), len(subs_log))
+
+        # Stats
+        LOG.info("[%s] %s: computing stats ...", split_name, fname)
+        means = np.nanmean(data_arr, axis=(0, 2, 3)).astype(np.float32)
+        stds  = np.nanstd (data_arr, axis=(0, 2, 3)).astype(np.float32)
+        np.save(stats_dir / f"{experiment_name}_{split_name}_means.npy", means)
+        np.save(stats_dir / f"{experiment_name}_{split_name}_stds.npy",  stds)
+        LOG.info("[%s] %s: saved stats under %s", split_name, fname, stats_dir)
+
+        # Zarr write
+        ds = xr.Dataset(
+            { f"{fname}": (["time", "channel", "y", "x"], data_arr) },
+            coords={
+                "time": datetime_array,
+                "channel": var_list,
+                "latitude": (["y", "x"], dummy_lat_grid),
+                "longitude": (["y", "x"], dummy_lon_grid),
+            }
+        )
+        enc = {f"{fname}": {"dtype": "float32", "compressor": None}}
+        out_store = Path(zarr_base) / fname / f"{experiment_name}_{split_name}.zarr"
+        out_store.parent.mkdir(parents=True, exist_ok=True)
+
+        LOG.info("[%s] %s: writing Zarr -> %s", split_name, fname, out_store)
+        t_z0 = time.perf_counter()
+        ds.to_zarr(str(out_store), mode="w", consolidated=True, encoding=enc, zarr_format=2)
+        zarr.consolidate_metadata(str(out_store))
+        t_z1 = time.perf_counter()
+        LOG.info("[%s] %s: Zarr write complete in %.1fs", split_name, fname, t_z1 - t_z0)
+
+        t1 = time.perf_counter()
+        LOG.info("[%s] %s: total elapsed %.1fs", split_name, fname, t1 - t0)
+
+    # Build HighRes / LowRes
+    build_level("HighRes", cache_highres, vars_highres)
+    build_level("LowRes",  cache_lowres,  vars_lowres)
+
+    # Invariants
+    LOG.info("[%s] Building invariants ...", split_name)
+    inv_arr = None
+    dt0 = None
+    for dt in list(datetime_array):
+        ok_all = True
+        for var in invariants:
+            if not os.path.exists(npz_path_for(cache_highres, var, dt)):
+                ok_all = False
+                break
+        if ok_all:
+            dt0 = dt
+            break
+    if dt0 is None:
+        raise FileNotFoundError("No timestamp where all invariants exist in HighRes cache.")
+    LOG.info("[%s] Using %s for invariants extraction", split_name, np.datetime_as_string(dt0, unit="h"))
+
+    for var in invariants:
+        path = npz_path_for(cache_highres, var, dt0)
+        dt_data, lon_grid, lat_grid, _ = u1.extract_region(
+            path, var, lon_min, lon_max, lat_min, lat_max, domain_size=domain_size
+        )
+        dt_data, lon_grid, lat_grid = u1.interp_to_domain(
+            lon_grid, lat_grid, dt_data, domain_size, method="linear"
+        )
+        inv_arr = dt_data.copy() if inv_arr is None else np.concatenate((inv_arr, dt_data), axis=0)
+
+    inv_ds = xr.Dataset(
+        { "HighRes_invariants": (["channel", "y", "x"], inv_arr) },
+        coords={
+            "channel": invariants,
+            "latitude": (["y", "x"], lat_grid),
+            "longitude": (["y", "x"], lon_grid),
+        }
+    )
+    inv_enc = {"HighRes_invariants": {"dtype": "float32", "compressor": None}}
+    inv_store = Path(zarr_base) / "invariants" / "invariants.zarr"
+    inv_store.parent.mkdir(parents=True, exist_ok=True)
+
+    LOG.info("[%s] Writing invariants Zarr -> %s", split_name, inv_store)
+    t_iz0 = time.perf_counter()
+    inv_ds.to_zarr(str(inv_store), mode="w", consolidated=True, encoding=inv_enc, zarr_format=2)
+    zarr.consolidate_metadata(str(inv_store))
+    t_iz1 = time.perf_counter()
+    LOG.info("[%s] Invariants write complete in %.1fs | shape=%s",
+             split_name, t_iz1 - t_iz0, tuple(inv_arr.shape))
+
+    t_split1 = time.perf_counter()
+    LOG.info("[%s] Split complete in %.1fs", split_name, t_split1 - t_split0)
+
+# -------------------- Main -------------------- #
+def main():
+    ap = argparse.ArgumentParser(
+        description="Build HighRes/LowRes Zarr datasets for train/valid splits from NPZ caches (multiprocessing, nearest-time substitution)."
+    )
+    # Variables (optional; fall back to defaults if omitted)
+    ap.add_argument("--var-lowres",  default=None,
+                    help="Comma-separated vars for LowRes. If omitted, built-in defaults are used.")
+    ap.add_argument("--var-highres", default=None,
+                    help="Comma-separated vars for HighRes. If omitted, built-in defaults are used.")
+    ap.add_argument("--var-dummy",   default=DEFAULT_DUMMY_VAR,
+                    help=f"Var used to infer dummy shape (default: {DEFAULT_DUMMY_VAR}).")
+    ap.add_argument("--invariants",  default=None,
+                    help=f"Comma-separated invariant vars (default: {','.join(DEFAULT_INVARIANTS)}).")
+
+    # Region / domain
+    ap.add_argument("--lon-min", type=float, required=True)
+    ap.add_argument("--lon-max", type=float, required=True)
+    ap.add_argument("--lat-min", type=float, required=True)
+    ap.add_argument("--lat-max", type=float, required=True)
+    ap.add_argument("--domain-size", required=True, help="H,W (e.g., 256,256)")
+
+    # Paths
+    ap.add_argument("--cache-highres", required=True, help="Folder containing HighRes NPZ files (e.g., rwrf cache).")
+    ap.add_argument("--cache-lowres",  required=True, help="Folder containing LowRes NPZ files (e.g., era5 cache).")
+    ap.add_argument("--zarr-base",     required=True, help="Output base directory for Zarr stores and stats.")
+    ap.add_argument("--experiment-name", required=True, help="Base name used in output Zarrs (e.g., 'stormcast_small').")
+
+    # Splits & ranges
+    ap.add_argument("--train-ranges", required=True,
+                    help="Comma-separated date ranges A:B (YYYY/MM/DD:YYYY/MM/DD).")
+    ap.add_argument("--valid-ranges", required=True,
+                    help="Comma-separated date ranges A:B (YYYY/MM/DD:YYYY/MM/DD) for validation.")
+    ap.add_argument("--split", choices=["train", "valid", "both"], default="both",
+                    help="Which split(s) to build.")
+
+    # MP + Logging
+    ap.add_argument("--workers", type=int, default=multiprocessing.cpu_count(),
+                    help="Number of worker processes for multiprocessing.")
+    ap.add_argument("--log-level", default="INFO", choices=["DEBUG","INFO","WARNING","ERROR"])
+    ap.add_argument("--log-file", default=None, help="Optional path to write logs.")
+
+    args = ap.parse_args()
+    setup_logging(args.log_level, args.log_file)
+
+    # Resolve variable lists (CLI overrides defaults if provided)
+    vars_lr  = parse_csv(args.var_lowres)  or DEFAULT_LOWRES_VARS
+    vars_hr  = parse_csv(args.var_highres) or DEFAULT_HIGHRES_VARS
+    inv_vars = parse_csv(args.invariants)  or DEFAULT_INVARIANTS
+    dummy_var = args.var_dummy
+    domain_size = parse_domain_size(args.domain_size)
+
+    LOG.info("Starting build experiment=%s split=%s workers=%d", args.experiment_name, args.split, args.workers)
+    LOG.info("HighRes vars=%d | LowRes vars=%d | Invariants=%s | Dummy=%s",
+             len(vars_hr), len(vars_lr), ",".join(inv_vars), dummy_var)
+    LOG.info("HighRes cache: %s | LowRes cache: %s", args.cache_highres, args.cache_lowres)
+
+    train_dt = concat_hourly(parse_ranges(args.train_ranges))
+    valid_dt = concat_hourly(parse_ranges(args.valid_ranges))
+
+    # Run selected splits
+    if args.split in ("train", "both"):
+        LOG.info("=== Building TRAIN split ===")
+        build_split(
+            split_name="train",
+            datetime_array=train_dt,
+            cache_highres=args.cache_highres,
+            cache_lowres=args.cache_lowres,
+            vars_highres=vars_hr,
+            vars_lowres=vars_lr,
+            dummy_var=dummy_var,
+            invariants=inv_vars,
+            lon_min=args.lon_min, lon_max=args.lon_max,
+            lat_min=args.lat_min, lat_max=args.lat_max,
+            domain_size=domain_size,
+            zarr_base=args.zarr_base,
+            experiment_name=args.experiment_name,
+            workers=args.workers,
+        )
+
+    if args.split in ("valid", "both"):
+        LOG.info("=== Building VALID split ===")
+        build_split(
+            split_name="valid",
+            datetime_array=valid_dt,
+            cache_highres=args.cache_highres,
+            cache_lowres=args.cache_lowres,
+            vars_highres=vars_hr,
+            vars_lowres=vars_lr,
+            dummy_var=dummy_var,
+            invariants=inv_vars,  # invariants are saved in a common store, reused
+            lon_min=args.lon_min, lon_max=args.lon_max,
+            lat_min=args.lat_min, lat_max=args.lat_max,
+            domain_size=domain_size,
+            zarr_base=args.zarr_base,
+            experiment_name=args.experiment_name,
+            workers=args.workers,
+        )
+
+    LOG.info("All done.")
+
+if __name__ == "__main__":
+    main()

--- a/dev/rwrf_process/des_npz_2_zarr/npz_2_zarr.py
+++ b/dev/rwrf_process/des_npz_2_zarr/npz_2_zarr.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 #
-# build_stormcast_zarr_mp.py
 #
 # Build HighRes/LowRes Zarr datasets (and invariants) from NPZ caches using fully
 # configurable CLI args. Supports two splits (train/valid) with one or multiple
@@ -292,6 +291,17 @@ def _load_timestamp_block(
             cache_dir, var, tgt_dt, avail_map.get(var, np.array([], dtype="datetime64[h]")),
             lon_min, lon_max, lat_min, lat_max, domain_size, dummy_data
         )
+
+        # ------------------------------
+        if data.ndim == 4 and data.shape[1] == 1:
+            # (1,1,H,W) → (1,H,W)
+            data = data[:, 0, :, :]
+        elif data.ndim == 2:
+            # (H,W) → (1,H,W)
+            data = data[None, :, :]
+        if data.ndim != 3:
+            raise ValueError(f"Unexpected shape {data.shape} for var={var} at {tgt_dt}")
+
         if substituted:
             tgt_str = np.datetime_as_string(tgt_dt, unit="h")
             if src_dt is None:
@@ -300,12 +310,37 @@ def _load_timestamp_block(
                 src_str = np.datetime_as_string(src_dt, unit="h")
                 subs_msgs.append(f"{var} {tgt_str} <- nearest {src_str}")
 
-        channel_arr = data.copy() if channel_arr is None else np.concatenate((channel_arr, data), axis=0)
+        # Concatenate (channels on axis=0). Add rich diagnostics if it fails.
+        if channel_arr is None:
+            channel_arr = data.copy()
+        else:
+            try:
+                channel_arr = np.concatenate((channel_arr, data), axis=0)
+            except ValueError as e:
+                LOG.error(
+                    "Concat failed at timestamp=%s var=%s | substituted=%s src_dt=%s\n"
+                    "  channel_arr: shape=%s ndim=%d dtype=%s\n"
+                    "  incoming   : shape=%s ndim=%d dtype=%s\n"
+                    "  Note: concatenation is along axis=0 (channel axis).",
+                    np.datetime_as_string(tgt_dt, unit="h"),
+                    var,
+                    substituted,
+                    (np.datetime_as_string(src_dt, unit='h') if src_dt is not None else "None"),
+                    getattr(channel_arr, 'shape', None),
+                    getattr(channel_arr, 'ndim', None),
+                    getattr(channel_arr, 'dtype', None),
+                    getattr(data, 'shape', None),
+                    getattr(data, 'ndim', None),
+                    getattr(data, 'dtype', None),
+                )
+                raise ValueError(
+                    f"Concatenation failed for var={var} at {np.datetime_as_string(tgt_dt, unit='h')}: "
+                    f"channel_arr shape={getattr(channel_arr, 'shape', None)} vs data shape={getattr(data, 'shape', None)}"
+                ) from e
 
     if channel_arr.ndim != 3:
         raise RuntimeError(f"Unexpected per-timestamp shape: {channel_arr.shape}")
     return idx, channel_arr, subs_msgs
-
 # -------------------- Split builder (MP) -------------------- #
 def build_split(
     split_name: str,

--- a/dev/rwrf_process/des_npz_2_zarr/npz_2_zarr.sh
+++ b/dev/rwrf_process/des_npz_2_zarr/npz_2_zarr.sh
@@ -9,7 +9,7 @@ PYTHONPATH="$UTIL_DIR:$PYTHONPATH" python npz_2_zarr.py \
     --cache-lowres  /workspace/NCDR_StormCast/des/npz/era5 \
     --zarr-base /workspace/NCDR_StormCast/des/zarr \
     --experiment-name stormcast_test \
-    --train-ranges "2019/08/01:2019/08/30" \
+    --train-ranges "2019/08/06:2019/08/06" \
     --valid-ranges "2019/09/01:2019/09/02" \
     --split train \
     --log-level DEBUG --log-file /workspace/physicsnemo/dev/rwrf_process/des_npz_2_zarr/npz_2_zarr.log \

--- a/dev/rwrf_process/des_npz_2_zarr/npz_2_zarr.sh
+++ b/dev/rwrf_process/des_npz_2_zarr/npz_2_zarr.sh
@@ -2,16 +2,14 @@
 UTIL_DIR="$(cd "$(dirname "$0")/.." && pwd)"   # parent of des_npz_2_zarr
 
 PYTHONPATH="$UTIL_DIR:$PYTHONPATH" python npz_2_zarr.py \
-    --var-lowres "u10,v10,t2m" \
-    --var-highres "u10,v10,t2m,qpepre" \
-    --var-dummy "t2m" \
     --invariants "lsm,orog" \
     --lon-min 121 --lon-max 125 --lat-min 21 --lat-max 25 \
     --domain-size 256,256 \
     --cache-highres /workspace/NCDR_StormCast/des/npz/rwrf \
     --cache-lowres  /workspace/NCDR_StormCast/des/npz/era5 \
     --zarr-base /workspace/NCDR_StormCast/des/zarr \
-    --experiment-name stormcast_small \
-    --train-ranges "2019/08/01:2019/08/31" \
-    --valid-ranges "2019/09/01:2019/09/07" \
+    --experiment-name stormcast_test \
+    --train-ranges "2019/08/01:2019/08/30" \
+    --valid-ranges "2019/09/01:2019/09/02" \
     --split train \
+    --log-level DEBUG --log-file /workspace/physicsnemo/dev/rwrf_process/des_npz_2_zarr/npz_2_zarr.log \

--- a/dev/rwrf_process/des_npz_2_zarr/npz_2_zarr.sh
+++ b/dev/rwrf_process/des_npz_2_zarr/npz_2_zarr.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+UTIL_DIR="$(cd "$(dirname "$0")/.." && pwd)"   # parent of des_npz_2_zarr
+
+PYTHONPATH="$UTIL_DIR:$PYTHONPATH" python npz_2_zarr.py \
+    --var-lowres "u10,v10,t2m" \
+    --var-highres "u10,v10,t2m,qpepre" \
+    --var-dummy "t2m" \
+    --invariants "lsm,orog" \
+    --lon-min 121 --lon-max 125 --lat-min 21 --lat-max 25 \
+    --domain-size 256,256 \
+    --cache-highres /workspace/NCDR_StormCast/des/npz/rwrf \
+    --cache-lowres  /workspace/NCDR_StormCast/des/npz/era5 \
+    --zarr-base /workspace/NCDR_StormCast/des/zarr \
+    --experiment-name stormcast_small \
+    --train-ranges "2019/08/01:2019/08/31" \
+    --valid-ranges "2019/09/01:2019/09/07" \
+    --split train \

--- a/examples/weather/stormcast/datasets/data_loader_small.py
+++ b/examples/weather/stormcast/datasets/data_loader_small.py
@@ -84,6 +84,13 @@ class Dataset(StormCastDataset):
         )[kept_LowRes_idx, None, None]
         self.invariants = params.invariants
 
+        # debug nan lowres
+        # File to save NaN channel logs
+        os.makedirs("logs", exist_ok=True)
+        self.nan_log_file = os.path.join("logs", f"nan_channels_{'train' if train else 'valid'}.txt")
+        with open(self.nan_log_file, "w") as f:
+            f.write("timestamp,channels\n")  # CSV-style header
+
     def background_channels(self):
         """Metadata for the background channels. A list of channel names, one for each channel"""
         return self.kept_LowRes_channels
@@ -278,6 +285,7 @@ class Dataset(StormCastDataset):
     def normalize_background(self, x: np.ndarray) -> np.ndarray:
         """Convert background from physical units to normalized data."""
         if self.normalize:
+            self.logger0.info(f"lowres- x: {x}, mean:{self.means_LowRes}, std:{self.stds_LowRes}")
             x -= self.means_LowRes
             x /= self.stds_LowRes
         return x
@@ -304,31 +312,52 @@ class Dataset(StormCastDataset):
         return x
 
     def _get_LowRes(self, ts_inp, ts_tar):
-        """
-        Retrieve LowRes samples from zarr files
-        """
-
         ds_inp, ds_tar, adjacent = self._get_ds_handles(
             self.ds_LowRes, self.LowRes_paths, ts_inp, ts_tar
         )
-
         inp_field = ds_inp.sel(time=ts_inp, channel=self.kept_LowRes_channels).LowRes.values
 
+        self.logger0.info(
+            f"_get_LowRes ts_inp={ts_inp}, shape={inp_field.shape}, "
+            f"channels={self.kept_LowRes_channels}"
+        )
+
         inp = self.normalize_background(inp_field)
+
+        nan_channels = [
+            ch for i, ch in enumerate(self.kept_LowRes_channels)
+            if np.isnan(inp[i]).any()
+        ]
+        if nan_channels:
+            self.logger0.warning(
+                f"[LowRes] NaNs detected after normalization at ts={ts_inp} in channels: {nan_channels}"
+            )
+            with open(self.nan_log_file, "a") as f:
+                f.write(f"{ts_inp},{'|'.join(nan_channels)}\n")
+
         return torch.as_tensor(inp)
 
     def _get_HighRes(self, ts_inp, ts_tar):
-        """
-        Retrieve HighRes samples from zarr files
-        """
         ds_inp, ds_tar, adjacent = self._get_ds_handles(
             self.ds_HighRes, self.HighRes_paths, ts_inp, ts_tar
         )
-
         inp_field = ds_inp.sel(time=ts_inp, channel=self.kept_HighRes_channels).HighRes.values
         tar_field = ds_tar.sel(time=ts_tar, channel=self.kept_HighRes_channels).HighRes.values
 
         inp, tar = self.normalize_state(inp_field), self.normalize_state(tar_field)
+
+        # Log NaNs
+        for arr, tag in [(inp, "inp"), (tar, "tar")]:
+            nan_channels = [
+                ch for i, ch in enumerate(self.kept_HighRes_channels)
+                if np.isnan(arr[i]).any()
+            ]
+            if nan_channels:
+                self.logger0.warning(
+                    f"[HighRes-{tag}] NaNs detected at ts={ts_inp}->{ts_tar} in channels: {nan_channels}"
+                )
+                with open(self.nan_log_file, "a") as f:
+                    f.write(f"{ts_inp}->{ts_tar},{'|'.join(nan_channels)}\n")
 
         return torch.as_tensor(inp), torch.as_tensor(tar)
 
@@ -337,8 +366,29 @@ class Dataset(StormCastDataset):
         Return data as a dict
         """
         time_pair = self._global_idx_to_datetime(global_idx)
+        ts_inp, ts_tar = time_pair
+        self.logger0.info(
+            f"Fetching sample idx={global_idx}, inp={ts_inp}, tar={ts_tar}"
+        )
+
         HighRes_pair = self._get_HighRes(*time_pair)
         LowRes_pair = self._get_LowRes(*time_pair)
+
+        # Log shapes and a quick summary
+        if isinstance(LowRes_pair, torch.Tensor):
+            self.logger0.info(
+                f"LowRes shape: {tuple(LowRes_pair.shape)} "
+                f"(min={LowRes_pair.min().item():.4f}, max={LowRes_pair.max().item():.4f})"
+            )
+        if isinstance(HighRes_pair, tuple):
+            inp, tar = HighRes_pair
+            self.logger0.info(
+                f"HighRes inp shape: {tuple(inp.shape)}, "
+                f"tar shape: {tuple(tar.shape)} "
+                f"(inp[min={inp.min().item():.4f}, max={inp.max().item():.4f}], "
+                f"tar[min={tar.min().item():.4f}, max={tar.max().item():.4f}])"
+            )
+
         return {
             "background": LowRes_pair,
             "state": HighRes_pair,

--- a/examples/weather/stormcast/utils/trainer.py
+++ b/examples/weather/stormcast/utils/trainer.py
@@ -45,6 +45,22 @@ from torch.nn.utils import clip_grad_norm_
 
 logger = PythonLogger("train")
 
+def print_dataset_info(dataset, name="dataset"):
+    logger0 = dataset.logger0 if hasattr(dataset, "logger0") else print
+    logger0.info(f"--- {name} info ---")
+    logger0.info(f"date_ranges: {dataset.date_ranges}")
+    logger0.info(f"LowRes_zarrs: {getattr(dataset, 'LowRes_zarrs', None)}")
+    logger0.info(f"HighRes_zarrs: {getattr(dataset, 'HighRes_zarrs', None)}")
+    logger0.info(f"LowRes_channels: {getattr(dataset, 'LowRes_channels', None)}")
+    logger0.info(f"HighRes_channels: {getattr(dataset, 'HighRes_channels', None)}")
+    logger0.info(f"n_samples_total: {getattr(dataset, 'n_samples_total', None)}")
+    logger0.info(f"valid_samples (first 5): {getattr(dataset, 'valid_samples', None)[:5]}")
+    logger0.info(f"image_shape: {dataset.image_shape()}")
+    logger0.info(f"background_channels: {dataset.background_channels()}")
+    logger0.info(f"state_channels: {dataset.state_channels()}")
+    logger0.info(f"invariants: {dataset.get_invariants()}")
+    logger0.info(f"-------------------")
+
 
 def training_loop(cfg):
 
@@ -95,10 +111,16 @@ def training_loop(cfg):
     logger0.info("Loading dataset...")
 
     dataset_cls = dataset_classes[cfg.dataset.name]
+    
+
+    logger0.info(f"Dataset class: {dataset_cls.__name__}")
+    # log dataset type
+    logger0.info(f"Dataset type: {cfg.dataset.name}")
     del cfg.dataset.name
 
     dataset_train = dataset_cls(cfg.dataset, train=True)
     dataset_valid = dataset_cls(cfg.dataset, train=False)
+    print_dataset_info(dataset_train, "Train")
 
     background_channels = dataset_train.background_channels()
     state_channels = dataset_train.state_channels()


### PR DESCRIPTION
# npz→zarr builder: fast MP ingest, nearest-time substitution, and invariant export

## What’s in this PR

This PR introduces a new, production-ready NPZ→Zarr pipeline focused on **speed, resilience to missing files, and reproducible output**. The core is `dev/rwrf_process/des_npz_2_zarr/npz_2_zarr.py`. It replaces ad-hoc scripts with a single, configurable CLI that:

- **Scans caches once** to build a `{var → sorted times}` index for O(1) nearest-time lookups.
- **Loads per-timestamp blocks in parallel** (multiprocessing) across all requested variables.
- **Fills gaps robustly**: if a file for `(var, t)` is missing, it substitutes the **nearest-in-time raw NPZ**; if a var is completely absent, it **falls back to zeros** shaped from a **dummy template var**.
- **Crops & optionally upscales to a domain** using shared helpers (`util_extract.extract_region`, `util_extract.interp_to_domain`).
- **Writes compact Zarr datasets** for `HighRes`, `LowRes`, and a single `invariants` store, with **consolidated metadata** and saved **channel-wise mean/std** for training.
- Provides **rich logging** and a **clear CLI** to control variables, splits, date ranges, workers, and domain.
- A new **Zarr inspector utility** (`dev/rwrf_process/des_npz_2_zarr/inspect_zarr.py`) to quickly check datasets and compute per-channel statistics.

---

## Key changes (npz_2_zarr.py)

- **CLI & Defaults**
  - New flags for paths, split selection, region bounds, domain size, worker count, logging, and the lists of LR/HR variables.
  - Safe defaults for variable sets (`DEFAULT_LOWRES_VARS`, `DEFAULT_HIGHRES_VARS`), invariants (`lsm`, `orog`), and dummy var (`t2m`).

- **Cache indexing (single pass)**
  - `scan_cache_index(cache_dir)` builds a map `{var: np.array(datetime64[h])}`.
  - File naming normalized to `var_YYYYMMDDHH.npz` via a single regex, reducing I/O churn.

- **Nearest-time substitution**
  - `load_or_nearest_by_cache(...)` attempts the target file, falls back to the **nearest** available hour (earlier wins on ties), or **zeros** if the var has no samples anywhere.
  - Per-timestamp worker `_load_timestamp_block(...)` concatenates channels with contextual error logs if shapes mismatch.

- **Parallel ingest (ProcessPoolExecutor)**
  - Each timestamp is a work unit; variables are loaded inside the worker.
  - Scales with `--workers` (defaults to `multiprocessing.cpu_count()`).

- **Geospatial crop & grid handling**
  - Uses `util_extract.extract_region` for lon/lat crop and `util_extract.interp_to_domain` to match `--domain-size` when cache tiles are smaller.
  - Dummy template is derived from either an **exact grid timestamp** for the dummy var or **first available** sample from cache index.

- **Invariants**
  - Extracted once from any timestamp that has **all** requested invariant variables present in the HighRes cache.
  - Coordinates (`latitude`, `longitude`) are written for downstream alignment.

- **Diagnostics**
  - Optional `--log-file` plus structured, progress-oriented logs (indexing, worker collection, stats, writes).
  - Helpful messages when channels are completely missing (immediate zero-fill).

---

## New helper script

- `dev/rwrf_process/des_npz_2_zarr/npz_2_zarr.sh`
  - Shows a realistic invocation with domain bounds, workers, and logging enabled.
  - Exports `PYTHONPATH` so shared utils are importable.

---

## Example usage

```bash
# from dev/rwrf_process/des_npz_2_zarr
PYTHONPATH="$(cd .. && pwd):$PYTHONPATH" \
python npz_2_zarr.py \
  --invariants "lsm,orog" \
  --lon-min 121 --lon-max 125 --lat-min 21 --lat-max 25 \
  --domain-size 256,256 \
  --cache-highres /workspace/NCDR_StormCast/des/npz/rwrf \
  --cache-lowres  /workspace/NCDR_StormCast/des/npz/era5 \
  --zarr-base /workspace/NCDR_StormCast/des/zarr \
  --experiment-name stormcast_test \
  --train-ranges "2019/08/01:2019/08/30" \
  --valid-ranges "2019/09/01:2019/09/02" \
  --split both \
  --log-level INFO --log-file /tmp/npz_2_zarr.log
  ```
  
  ## `inspect_zarr.py`

A lightweight tool to **inspect StormCast Zarr datasets** and compute **nan-aware statistics**.  

### Features
- Supports Zarr written by `npz_2_zarr.py` (variables `HighRes` or `LowRes`).
- **Auto-detects** variable to inspect (or pass via `--var`).
- Computes per-time, per-channel **min, max, mean, std** (NaN-safe).
- Logs progress to both stdout and file.
- Optional **CSV export** for later analysis.
- Works on full dataset or a limited number of hours (`--first-n-hours`) for quick checks.
- Computes **global per-channel stats** across all time steps at the end.

### Example usage

```bash
python zarr_inspect.py /workspace/NCDR_StormCast/des/zarr/HighRes/stormcast_test_train.zarr \
    --var HighRes \
    --log inspect_highres.log \
    --csv inspect_highres.csv \
    --first-n-hours 48
```

- **Outputs & stats**
  - Writes Zarr stores under:
    - `.../HighRes/{experiment}_{split}.zarr`
    - `.../LowRes/{experiment}_{split}.zarr`
    - `.../invariants/invariants.zarr`
  - Saves `means.npy` and `stds.npy` per level in `.../{HighRes|LowRes}/stats/`.
  - Uses `zarr_format=2` and consolidates metadata for speed at read time.
```