### PR TITLE
Feature: rwrf qpepre era5 training configs

### DIFF
--- a/examples/weather/stormcast/config/dataset/rwrf_qpe_era5.yaml
+++ b/examples/weather/stormcast/config/dataset/rwrf_qpe_era5.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: data_loader_rwrf_qpe_era5.Dataset # Dataset class module and name, in any module in `datasets` folder
+
+# Main dataset
+# change the path to your local data
+location: '/workspace/data/StormCast_data/exp_3_train_2_5_yrs_val_1yr/zarr_exp3_L_24_H_24_train_2_5_years_full_6hrs' # Path to the dataset
+
+# Domain
+HighRes_img_size: [224, 128] 
+
+# Temporal selection
+dt: 1 # Timestep between samples (in multiples of the base HRRR 1hr timestep)
+exp_train_zarrs: ["stormcast_test_train"] # Zarr files to use for training, change for your needs
+train_dates: ['2019/08/01', '2021/12/31']
+exp_valid_zarrs: ["stormcast_test_valid"] # Zarr files to use for validation, change for your needs
+valid_dates: ['2022/01/01', '2022/12/31']
+
+# Variable selection
+invariants: ["lsm", "orog"] # Invariant quantitites to include
+input_channels: 'all' #'all' or list of channels to condition on
+diffusion_channels: "all" #'all' or list of channels to condition on
+kept_LowRes_channels: "all"
+kept_HighRes_channels: "all"

--- a/examples/weather/stormcast/config/regression_rwrf_qpe_era5.yaml
+++ b/examples/weather/stormcast/config/regression_rwrf_qpe_era5.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Defaults
+defaults:
+
+  # Dataset
+  - dataset/rwrf_qpe_era5
+
+  # Model
+  - model/stormcast
+
+  # Training
+  - training/rwrf_qpe_era5
+
+  # Sampler
+  - sampler/edm_deterministic
+
+  # Hydra
+  - hydra/default
+
+  - _self_

--- a/examples/weather/stormcast/config/training/rwrf_qpe_era5.yaml
+++ b/examples/weather/stormcast/config/training/rwrf_qpe_era5.yaml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# General training config items
+outdir: 'StormCast_rwrf_qpepre_era5' # Root path under which to save training outputs
+experiment_name: 'exp_3_L_24_H_4_train_2_5_years_6hrs_same' # Name for the training experiment
+run_id: '1' # Unique ID to use for this training run
+rundir: ./${training.outdir}/${training.experiment_name}/${training.run_id} # Path where experiement outputs will be saved
+num_data_workers: 4 # Number of dataloader worker threads per proc
+log_to_wandb: False # Whether or not to log to Weights & Biases (requires wandb account)
+wandb_mode: "online" # logging mode, "online" or "offline"
+seed: -1 # Specify a random seed by setting this to an int > 0
+cudnn_benchmark: True # Enable/disable CuDNN benchmark mode
+resume_checkpoint: "latest" # epoch number to continue training from, or "latest" for the latest checkpoint
+initial_weights: null # if not null, a .mdlus checkpoint to load weights at the start of training; no effect if training continues from a checkpoint
+
+# Logging frequency
+print_progress_freq: 1 # How often to print progress, measured in number of training steps
+checkpoint_freq: 500 # How often to save the checkpoints, measured in number of training steps
+validation_freq: 1 # how often to record the validation loss, measured in number of training steps
+
+# Optimization hyperparameters
+batch_size: 2 # Total training batch size -- must be >= (and divisble by) number of GPUs being used
+batch_size_per_gpu: "auto" # Batch size on each GPU, set to an int to force smaller local batch with gradient accumulation
+lr: 4E-4 # Initial learning rate
+lr_rampup_steps: 1000 # Number of training steps over which to perform linear LR warmup
+total_train_steps: 16000 # Number of total training steps, 16000 with batch size 64 corresponds to StormCast paper regression
+clip_grad_norm: -1 # Threshold for gradient clipping, set to -1 to disable
+loss: 'regression' # Loss type; use 'regression' or 'edm' for the regression and diffusion, respectively
+fp_optimizations: fp32 # Floating point mode, one of ["fp32", "amp-fp16", "amp-bf16"]
+compile_model: False # use torch.compile to compile model
+
+# Validation options
+validation_plot_variables: ["t2m", "u10", "v10", "qpepre"]


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
added three yaml files for rwrf qpepre era5 training with clear names:
- dataset/rwrf_qpe_era5.yaml
- regression_rwrf_qpe_era5.yaml
- training/rwrf_qpe_era5.yaml

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->